### PR TITLE
Support Exceptions without stack trace

### DIFF
--- a/asa-manager/WebService.Test/v1/Filters/ExceptionsFilterAttributeTest.cs
+++ b/asa-manager/WebService.Test/v1/Filters/ExceptionsFilterAttributeTest.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Azure.IoTSolutions.AsaManager.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.AsaManager.WebService.v1.Filters;
+using Moq;
+using WebService.Test.helpers;
+using Xunit;
+
+namespace WebService.Test.v1.Filters
+{
+    public class ExceptionsFilterAttributeTest
+    {
+        private readonly ExceptionsFilterAttribute target;
+
+        public ExceptionsFilterAttributeTest()
+        {
+            this.target = new ExceptionsFilterAttribute();
+        }
+
+        /// <summary>
+        /// When handling unknown/unexpected exceptions, the stack trace could be null,
+        /// the filter must support this scenario.
+        /// </summary>
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void DoesntFail_When_StackTracesAreNull()
+        {
+            // Arrange
+            var internalException = new Mock<Exception>();
+            var exception = new Exception("", internalException.Object);
+            internalException.SetupGet(x => x.StackTrace).Returns((string)null);
+
+            var context = new ExceptionContext(
+                new ActionContext(
+                    new DefaultHttpContext(),
+                    new RouteData(),
+                    new ActionDescriptor(),
+                    new ModelStateDictionary()),
+                new List<IFilterMetadata>())
+            { Exception = exception };
+
+            // Act
+            this.target.OnException(context);
+
+            // Assert
+            var result = (ObjectResult)context.Result;
+            Assert.Equal((int)HttpStatusCode.InternalServerError, result.StatusCode.Value);
+
+            var content = (Dictionary<string, object>)result.Value;
+            Assert.True(content.ContainsKey("StackTrace"));
+            Assert.True(content.ContainsKey("InnerExceptionStackTrace"));
+            Assert.Null(content["StackTrace"]);
+            Assert.Null(content["InnerExceptionStackTrace"]);
+        }
+    }
+}

--- a/asa-manager/WebService/v1/Filters/ExceptionsFilterAttribute.cs
+++ b/asa-manager/WebService/v1/Filters/ExceptionsFilterAttribute.cs
@@ -83,14 +83,14 @@ namespace Microsoft.Azure.IoTSolutions.AsaManager.WebService.v1.Filters
 
             if (stackTrace)
             {
-                error["StackTrace"] = e.StackTrace.Split(new[] { "\n" }, StringSplitOptions.None);
+                error["StackTrace"] = e.StackTrace?.Split(new[] { "\n" }, StringSplitOptions.None);
 
                 if (e.InnerException != null)
                 {
                     e = e.InnerException;
                     error["InnerExceptionMessage"] = e.Message;
                     error["InnerExceptionType"] = e.GetType().FullName;
-                    error["InnerExceptionStackTrace"] = e.StackTrace.Split(new[] { "\n" }, StringSplitOptions.None);
+                    error["InnerExceptionStackTrace"] = e.StackTrace?.Split(new[] { "\n" }, StringSplitOptions.None);
                 }
             }
 

--- a/device-simulation/WebService.Test/v1/Filters/ExceptionsFilterAttributeTest.cs
+++ b/device-simulation/WebService.Test/v1/Filters/ExceptionsFilterAttributeTest.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Filters;
+using Moq;
+using WebService.Test.helpers;
+using Xunit;
+
+namespace WebService.Test.v1.Filters
+{
+    public class ExceptionsFilterAttributeTest
+    {
+        private readonly ExceptionsFilterAttribute target;
+
+        public ExceptionsFilterAttributeTest()
+        {
+            this.target = new ExceptionsFilterAttribute();
+        }
+
+        /// <summary>
+        /// When handling unknown/unexpected exceptions, the stack trace could be null,
+        /// the filter must support this scenario.
+        /// </summary>
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void Doesnt_Fail_When_StackTraces_AreNull()
+        {
+            // Arrange
+            var internalException = new Mock<Exception>();
+            var exception = new Exception("", internalException.Object);
+            internalException.SetupGet(x => x.StackTrace).Returns((string)null);
+
+            var context = new ExceptionContext(
+                new ActionContext(
+                    new DefaultHttpContext(),
+                    new RouteData(),
+                    new ActionDescriptor(),
+                    new ModelStateDictionary()),
+                new List<IFilterMetadata>())
+            { Exception = exception };
+
+            // Act
+            this.target.OnException(context);
+
+            // Assert
+            var result = (ObjectResult)context.Result;
+            Assert.Equal((int)HttpStatusCode.InternalServerError, result.StatusCode.Value);
+
+            var content = (Dictionary<string, object>)result.Value;
+            Assert.True(content.ContainsKey("StackTrace"));
+            Assert.True(content.ContainsKey("InnerExceptionStackTrace"));
+            Assert.Null(content["StackTrace"]);
+            Assert.Null(content["InnerExceptionStackTrace"]);
+        }
+    }
+}

--- a/device-simulation/WebService/v1/Filters/ExceptionsFilterAttribute.cs
+++ b/device-simulation/WebService/v1/Filters/ExceptionsFilterAttribute.cs
@@ -90,14 +90,14 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.v1.Filters
 
             if (stackTrace)
             {
-                error["StackTrace"] = e.StackTrace.Split(new[] { "\n" }, StringSplitOptions.None);
+                error["StackTrace"] = e.StackTrace?.Split(new[] { "\n" }, StringSplitOptions.None);
 
                 if (e.InnerException != null)
                 {
                     e = e.InnerException;
                     error["InnerExceptionMessage"] = e.Message;
                     error["InnerExceptionType"] = e.GetType().FullName;
-                    error["InnerExceptionStackTrace"] = e.StackTrace.Split(new[] { "\n" }, StringSplitOptions.None);
+                    error["InnerExceptionStackTrace"] = e.StackTrace?.Split(new[] { "\n" }, StringSplitOptions.None);
                 }
             }
 

--- a/device-telemetry/WebService.Test/v1/Filters/ExceptionsFilterAttributeTest.cs
+++ b/device-telemetry/WebService.Test/v1/Filters/ExceptionsFilterAttributeTest.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Filters;
+using Moq;
+using WebService.Test.helpers;
+using Xunit;
+
+namespace WebService.Test.v1.Filters
+{
+    public class ExceptionsFilterAttributeTest
+    {
+        private readonly ExceptionsFilterAttribute target;
+        private readonly Mock<ILogger> logger;
+
+        public ExceptionsFilterAttributeTest()
+        {
+            this.logger = new Mock<ILogger>();
+            this.target = new ExceptionsFilterAttribute(this.logger.Object);
+        }
+
+        /// <summary>
+        /// When handling unknown/unexpected exceptions, the stack trace could be null,
+        /// the filter must support this scenario.
+        /// </summary>
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void Doesnt_Fail_When_StackTraces_AreNull()
+        {
+            // Arrange
+            var internalException = new Mock<Exception>();
+            var exception = new Exception("", internalException.Object);
+            internalException.SetupGet(x => x.StackTrace).Returns((string)null);
+
+            var context = new ExceptionContext(
+                new ActionContext(
+                    new DefaultHttpContext(),
+                    new RouteData(),
+                    new ActionDescriptor(),
+                    new ModelStateDictionary()),
+                new List<IFilterMetadata>())
+            { Exception = exception };
+
+            // Act
+            this.target.OnException(context);
+
+            // Assert
+            var result = (ObjectResult)context.Result;
+            Assert.Equal((int)HttpStatusCode.InternalServerError, result.StatusCode.Value);
+
+            var content = (Dictionary<string, object>)result.Value;
+            Assert.True(content.ContainsKey("StackTrace"));
+            Assert.True(content.ContainsKey("InnerExceptionStackTrace"));
+            Assert.Null(content["StackTrace"]);
+            Assert.Null(content["InnerExceptionStackTrace"]);
+        }
+    }
+}

--- a/device-telemetry/WebService/v1/Filters/ExceptionsFilterAttribute.cs
+++ b/device-telemetry/WebService/v1/Filters/ExceptionsFilterAttribute.cs
@@ -98,14 +98,14 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Filters
 
             if (stackTrace)
             {
-                error["StackTrace"] = e.StackTrace.Split(new[] { "\n" }, StringSplitOptions.None);
+                error["StackTrace"] = e.StackTrace?.Split(new[] { "\n" }, StringSplitOptions.None);
 
                 if (e.InnerException != null)
                 {
                     e = e.InnerException;
                     error["InnerExceptionMessage"] = e.Message;
                     error["InnerExceptionType"] = e.GetType().FullName;
-                    error["InnerExceptionStackTrace"] = e.StackTrace.Split(new[] { "\n" }, StringSplitOptions.None);
+                    error["InnerExceptionStackTrace"] = e.StackTrace?.Split(new[] { "\n" }, StringSplitOptions.None);
                 }
             }
 

--- a/iothub-manager/WebService.Test/v1/Filters/ExceptionsFilterAttributeTest.cs
+++ b/iothub-manager/WebService.Test/v1/Filters/ExceptionsFilterAttributeTest.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Filters;
+using Moq;
+using WebService.Test.helpers;
+using Xunit;
+
+namespace WebService.Test.v1.Filters
+{
+    public class ExceptionsFilterAttributeTest
+    {
+        private readonly ExceptionsFilterAttribute target;
+
+        public ExceptionsFilterAttributeTest()
+        {
+            this.target = new ExceptionsFilterAttribute();
+        }
+
+        /// <summary>
+        /// When handling unknown/unexpected exceptions, the stack trace could be null,
+        /// the filter must support this scenario.
+        /// </summary>
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void Doesnt_Fail_When_StackTraces_AreNull()
+        {
+            // Arrange
+            var internalException = new Mock<Exception>();
+            var exception = new Exception("", internalException.Object);
+            internalException.SetupGet(x => x.StackTrace).Returns((string)null);
+
+            var context = new ExceptionContext(
+                new ActionContext(
+                    new DefaultHttpContext(),
+                    new RouteData(),
+                    new ActionDescriptor(),
+                    new ModelStateDictionary()),
+                new List<IFilterMetadata>())
+            { Exception = exception };
+
+            // Act
+            this.target.OnException(context);
+
+            // Assert
+            var result = (ObjectResult)context.Result;
+            Assert.Equal((int)HttpStatusCode.InternalServerError, result.StatusCode.Value);
+
+            var content = (Dictionary<string, object>)result.Value;
+            Assert.True(content.ContainsKey("StackTrace"));
+            Assert.True(content.ContainsKey("InnerExceptionStackTrace"));
+            Assert.Null(content["StackTrace"]);
+            Assert.Null(content["InnerExceptionStackTrace"]);
+        }
+    }
+}

--- a/iothub-manager/WebService/v1/Filters/ExceptionsFilterAttribute.cs
+++ b/iothub-manager/WebService/v1/Filters/ExceptionsFilterAttribute.cs
@@ -97,14 +97,14 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Filters
 
             if (stackTrace)
             {
-                error["StackTrace"] = e.StackTrace.Split(new[] { "\n" }, StringSplitOptions.None);
+                error["StackTrace"] = e.StackTrace?.Split(new[] { "\n" }, StringSplitOptions.None);
 
                 if (e.InnerException != null)
                 {
                     e = e.InnerException;
                     error["InnerExceptionMessage"] = e.Message;
                     error["InnerExceptionType"] = e.GetType().FullName;
-                    error["InnerExceptionStackTrace"] = e.StackTrace.Split(new[] { "\n" }, StringSplitOptions.None);
+                    error["InnerExceptionStackTrace"] = e.StackTrace?.Split(new[] { "\n" }, StringSplitOptions.None);
                 }
             }
 

--- a/pcs-auth/WebService.Test/v1/Filters/ExceptionsFilterAttributeTest.cs
+++ b/pcs-auth/WebService.Test/v1/Filters/ExceptionsFilterAttributeTest.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Azure.IoTSolutions.Auth.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.Auth.WebService.v1.Filters;
+using Moq;
+using WebService.Test.helpers;
+using Xunit;
+
+namespace WebService.Test.v1.Filters
+{
+    public class ExceptionsFilterAttributeTest
+    {
+        private readonly ExceptionsFilterAttribute target;
+        private readonly Mock<ILogger> logger;
+
+        public ExceptionsFilterAttributeTest()
+        {
+            this.logger = new Mock<ILogger>();
+            this.target = new ExceptionsFilterAttribute(this.logger.Object);
+        }
+
+        /// <summary>
+        /// When handling unknown/unexpected exceptions, the stack trace could be null,
+        /// the filter must support this scenario.
+        /// </summary>
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void Doesnt_Fail_When_StackTraces_AreNull()
+        {
+            // Arrange
+            var internalException = new Mock<Exception>();
+            var exception = new Exception("", internalException.Object);
+            internalException.SetupGet(x => x.StackTrace).Returns((string)null);
+
+            var context = new ExceptionContext(
+                new ActionContext(
+                    new DefaultHttpContext(),
+                    new RouteData(),
+                    new ActionDescriptor(),
+                    new ModelStateDictionary()),
+                new List<IFilterMetadata>())
+            { Exception = exception };
+
+            // Act
+            this.target.OnException(context);
+
+            // Assert
+            var result = (ObjectResult)context.Result;
+            Assert.Equal((int)HttpStatusCode.InternalServerError, result.StatusCode.Value);
+
+            var content = (Dictionary<string, object>)result.Value;
+            Assert.True(content.ContainsKey("StackTrace"));
+            Assert.True(content.ContainsKey("InnerExceptionStackTrace"));
+            Assert.Null(content["StackTrace"]);
+            Assert.Null(content["InnerExceptionStackTrace"]);
+        }
+    }
+}

--- a/pcs-auth/WebService/v1/Filters/ExceptionsFilterAttribute.cs
+++ b/pcs-auth/WebService/v1/Filters/ExceptionsFilterAttribute.cs
@@ -84,14 +84,14 @@ namespace Microsoft.Azure.IoTSolutions.Auth.WebService.v1.Filters
 
             if (stackTrace)
             {
-                error["StackTrace"] = e.StackTrace.Split(new[] { "\n" }, StringSplitOptions.None);
+                error["StackTrace"] = e.StackTrace?.Split(new[] { "\n" }, StringSplitOptions.None);
 
                 if (e.InnerException != null)
                 {
                     e = e.InnerException;
                     error["InnerExceptionMessage"] = e.Message;
                     error["InnerExceptionType"] = e.GetType().FullName;
-                    error["InnerExceptionStackTrace"] = e.StackTrace.Split(new[] { "\n" }, StringSplitOptions.None);
+                    error["InnerExceptionStackTrace"] = e.StackTrace?.Split(new[] { "\n" }, StringSplitOptions.None);
                 }
             }
 

--- a/pcs-config/WebService.Test/v1/Filters/ExceptionsFilterAttributeTest.cs
+++ b/pcs-config/WebService.Test/v1/Filters/ExceptionsFilterAttributeTest.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Azure.IoTSolutions.UIConfig.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.UIConfig.WebService.v1.Filters;
+using Moq;
+using WebService.Test.helpers;
+using Xunit;
+
+namespace WebService.Test.v1.Filters
+{
+    public class ExceptionsFilterAttributeTest
+    {
+        private readonly ExceptionsFilterAttribute target;
+        private readonly Mock<ILogger> logger;
+
+        public ExceptionsFilterAttributeTest()
+        {
+            this.logger = new Mock<ILogger>();
+            this.target = new ExceptionsFilterAttribute(this.logger.Object);
+        }
+
+        /// <summary>
+        /// When handling unknown/unexpected exceptions, the stack trace could be null,
+        /// the filter must support this scenario.
+        /// </summary>
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void Doesnt_Fail_When_StackTraces_AreNull()
+        {
+            // Arrange
+            var internalException = new Mock<Exception>();
+            var exception = new Exception("", internalException.Object);
+            internalException.SetupGet(x => x.StackTrace).Returns((string)null);
+
+            var context = new ExceptionContext(
+                new ActionContext(
+                    new DefaultHttpContext(),
+                    new RouteData(),
+                    new ActionDescriptor(),
+                    new ModelStateDictionary()),
+                new List<IFilterMetadata>())
+            { Exception = exception };
+
+            // Act
+            this.target.OnException(context);
+
+            // Assert
+            var result = (ObjectResult)context.Result;
+            Assert.Equal((int)HttpStatusCode.InternalServerError, result.StatusCode.Value);
+
+            var content = (Dictionary<string, object>)result.Value;
+            Assert.True(content.ContainsKey("StackTrace"));
+            Assert.True(content.ContainsKey("InnerExceptionStackTrace"));
+            Assert.Null(content["StackTrace"]);
+            Assert.Null(content["InnerExceptionStackTrace"]);
+        }
+    }
+}

--- a/pcs-config/WebService/v1/Filters/ExceptionsFilterAttribute.cs
+++ b/pcs-config/WebService/v1/Filters/ExceptionsFilterAttribute.cs
@@ -98,14 +98,14 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.v1.Filters
 
             if (stackTrace)
             {
-                error["StackTrace"] = e.StackTrace.Split(new[] { "\n" }, StringSplitOptions.None);
+                error["StackTrace"] = e.StackTrace?.Split(new[] { "\n" }, StringSplitOptions.None);
 
                 if (e.InnerException != null)
                 {
                     e = e.InnerException;
                     error["InnerExceptionMessage"] = e.Message;
                     error["InnerExceptionType"] = e.GetType().FullName;
-                    error["InnerExceptionStackTrace"] = e.StackTrace.Split(new[] { "\n" }, StringSplitOptions.None);
+                    error["InnerExceptionStackTrace"] = e.StackTrace?.Split(new[] { "\n" }, StringSplitOptions.None);
                 }
             }
 


### PR DESCRIPTION


# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
<!-- Please provide enough information so others can review your pull request -->
ExceptionsFilterAttribute has a null exception if the stack trace is null. Check if stack trace is null before trying to operate on it. This change has already been done in storage adapter, adding it to all the other microservices.

# Motivation for the change
<!-- Please explain the motivation for making this change -->
...
