### PR TITLE
Add deployment status per device to deployments controller

### DIFF
--- a/auth/Services.Test/UsersTest.cs
+++ b/auth/Services.Test/UsersTest.cs
@@ -134,7 +134,11 @@ namespace Services.Test
                 "UpdateRules",
                 "DeleteRules",
                 "CreateJobs",
-                "UpdateSimManagement"
+                "UpdateSimManagement",
+                "CreateDeployments",
+                "DeleteDeployments",
+                "CreatePackages",
+                "DeletePackages"
             };
 
             return new Policy()
@@ -157,7 +161,11 @@ namespace Services.Test
                 "CreateRules",
                 "UpdateRules",
                 "CreateJobs",
-                "UpdateSimManagement"
+                "UpdateSimManagement",
+                "CreateDeployments",
+                "DeleteDeployments",
+                "CreatePackages",
+                "DeletePackages"
             };
 
             return new Policy()

--- a/auth/Services/data/policies/roles.json
+++ b/auth/Services/data/policies/roles.json
@@ -16,7 +16,11 @@
                 "UpdateRules",
                 "DeleteRules",
                 "CreateJobs",
-                "UpdateSimManagement"
+                "UpdateSimManagement",
+                "CreateDeployments",
+                "DeleteDeployments",
+                "CreatePackages",
+                "DeletePackages"
             ]
         },
         {

--- a/auth/docs/POLICIES.md
+++ b/auth/docs/POLICIES.md
@@ -26,7 +26,11 @@ Role Policy Example:
                 "UpdateRules",
                 "DeleteRules",
                 "CreateJobs",
-                "UpdateSimManagement"
+                "UpdateSimManagement",
+                "CreateDeployment",
+                "DeleteDeployment",
+                "CreatePackage",
+                "DeletePackage"
             ]
         },
         {

--- a/config/WebService/v1/Controllers/PackageController.cs
+++ b/config/WebService/v1/Controllers/PackageController.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.v1.Controllers
         }
 
         [HttpPost]
+        [Authorize("CreatePackages")]
         public async Task<PackageApiModel> PostAsync(string type, IFormFile package)
         {
             if (string.IsNullOrEmpty(type))
@@ -76,6 +77,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.v1.Controllers
         }
 
         [HttpDelete("{id}")]
+        [Authorize("DeletePackages")]
         public async Task DeleteAsync(string id)
         {
             if (string.IsNullOrEmpty(id))

--- a/iothub-manager/Services.Test/DeploymentsTest.cs
+++ b/iothub-manager/Services.Test/DeploymentsTest.cs
@@ -114,6 +114,7 @@ namespace Services.Test
                                                string packageId, int priority,
                                                string expectedException)
         {
+            // Arrange
             var depModel = new DeploymentServiceModel()
             {
                 Name = deploymentName,
@@ -157,9 +158,12 @@ namespace Services.Test
                     c.Labels[DEPLOYMENT_PACKAGE_ID_LABEL] == packageId)))
                 .ReturnsAsync(newConfig);
 
+            // Act
             if (string.IsNullOrEmpty(expectedException))
             {
                 var createdDeployment = await this.deployments.CreateAsync(depModel);
+
+                // Assert
                 Assert.False(string.IsNullOrEmpty(createdDeployment.Id));
                 Assert.Equal(deploymentName, createdDeployment.Name);
                 Assert.Equal(packageId, createdDeployment.PackageId);
@@ -191,6 +195,7 @@ namespace Services.Test
         [InlineData(5)]
         public async Task GetDeploymentsTest(int numDeployments)
         {
+            // Arrange
             var configurations = new List<Configuration>();
             for (int i = numDeployments - 1; i >= 0; i--)
             {
@@ -199,7 +204,10 @@ namespace Services.Test
 
             this.registry.Setup(r => r.GetConfigurationsAsync(20)).ReturnsAsync(configurations);
 
+            // Act
             var returnedDeployments = await this.deployments.ListAsync();
+
+            // Assert
             Assert.Equal(numDeployments, returnedDeployments.Items.Count);
 
             // verify deployments are ordered by name
@@ -212,6 +220,7 @@ namespace Services.Test
         [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
         public async Task GetDeploymentsWithDeviceStatusTest()
         {
+            // Arrange
             var configuration = this.CreateConfiguration(0, true);
             var deploymentId = configuration.Id;
             this.registry.Setup(r => r.GetConfigurationAsync(deploymentId)).ReturnsAsync(configuration);
@@ -219,18 +228,22 @@ namespace Services.Test
             IQuery queryResult = new ResultQuery(3);
             this.registry.Setup(r => r.CreateQuery(It.IsAny<string>())).Returns(queryResult);
 
+            // Act
             var returnedDeployment = await this.deployments.GetAsync(deploymentId);
-            var deviceStatuses = returnedDeployment.DeploymentMetrics.DeviceWithStatus;
+            var deviceStatuses = returnedDeployment.DeploymentMetrics.DeviceStatuses;
+
+            // Assert
             Assert.Null(deviceStatuses);
 
             returnedDeployment = await this.deployments.GetAsync(deploymentId, true);
-            deviceStatuses = returnedDeployment.DeploymentMetrics.DeviceWithStatus;
+            deviceStatuses = returnedDeployment.DeploymentMetrics.DeviceStatuses;
             Assert.Equal(3, deviceStatuses.Count);
         }
 
         [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
         public async Task FilterOutNonRmDeploymentsTest()
         {
+            // Arrange
             var configurations = new List<Configuration>
             {
                 this.CreateConfiguration(0, true),
@@ -240,7 +253,10 @@ namespace Services.Test
             this.registry.Setup(r => r.GetConfigurationsAsync(20))
                 .ReturnsAsync(configurations);
 
+            // Act
             var returnedDeployments = await this.deployments.ListAsync();
+
+            // Assert
             Assert.Single(returnedDeployments.Items);
             Assert.Equal("deployment0", returnedDeployments.Items[0].Name);
         }

--- a/iothub-manager/Services.Test/DeploymentsTest.cs
+++ b/iothub-manager/Services.Test/DeploymentsTest.cs
@@ -210,6 +210,25 @@ namespace Services.Test
         }
 
         [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public async Task GetDeploymentsWithDeviceStatusTest()
+        {
+            var configuration = this.CreateConfiguration(0, true);
+            var deploymentId = configuration.Id;
+            this.registry.Setup(r => r.GetConfigurationAsync(deploymentId)).ReturnsAsync(configuration);
+
+            IQuery queryResult = new ResultQuery(3);
+            this.registry.Setup(r => r.CreateQuery(It.IsAny<string>())).Returns(queryResult);
+
+            var returnedDeployment = await this.deployments.GetAsync(deploymentId);
+            var deviceStatuses = returnedDeployment.DeploymentMetrics.DeviceWithStatus;
+            Assert.Null(deviceStatuses);
+
+            returnedDeployment = await this.deployments.GetAsync(deploymentId, true);
+            deviceStatuses = returnedDeployment.DeploymentMetrics.DeviceWithStatus;
+            Assert.Equal(3, deviceStatuses.Count);
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
         public async Task FilterOutNonRmDeploymentsTest()
         {
             var configurations = new List<Configuration>

--- a/iothub-manager/Services.Test/DevicesTest.cs
+++ b/iothub-manager/Services.Test/DevicesTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices;
 using Microsoft.Azure.Devices.Shared;
@@ -97,83 +96,6 @@ namespace Services.Test
             twin.Properties.Reported = new TwinCollection("{\"test\":\"value" + valueToReport + "\"}");
             twin.Properties.Desired = new TwinCollection("{\"test\":\"value" + valueToReport + "\"}");
             return twin;
-        }
-
-        private class ResultQuery : IQuery
-        {
-            private readonly List<Twin> results;
-
-            public ResultQuery(int numResults)
-            {
-                this.results = new List<Twin>();
-                for(int i = 0; i < numResults; i++)
-                {
-                    this.results.Add(DevicesTest.CreateTestTwin(i));
-                    this.HasMoreResults = true;
-                }
-            }
-            public Task<IEnumerable<Twin>> GetNextAsTwinAsync()
-            {
-                this.HasMoreResults = false;
-                return Task.FromResult<IEnumerable<Twin>>(this.results);
-            }
-
-            public Task<QueryResponse<Twin>> GetNextAsTwinAsync(QueryOptions options)
-            {
-                this.HasMoreResults = false;
-                QueryResponse<Twin> resultResponse;
-
-                if (string.IsNullOrEmpty(options.ContinuationToken))
-                {
-                    resultResponse = new QueryResponse<Twin>(this.results, "continuationToken");
-                }
-                else
-                {
-                    var index = int.Parse(options.ContinuationToken);
-                    var count = this.results.Count - index;
-
-                    var continuedResults = new List<Twin>();
-                    if (index < count)
-                    {
-                        continuedResults = this.results.GetRange(index, count);
-                    }
-                    resultResponse = new QueryResponse<Twin>(continuedResults, "continuationToken");
-                }
-
-                return Task.FromResult(resultResponse);
-            }
-
-            public Task<IEnumerable<DeviceJob>> GetNextAsDeviceJobAsync()
-            {
-                throw new System.NotImplementedException();
-            }
-
-            public Task<QueryResponse<DeviceJob>> GetNextAsDeviceJobAsync(QueryOptions options)
-            {
-                throw new System.NotImplementedException();
-            }
-
-            public Task<IEnumerable<JobResponse>> GetNextAsJobResponseAsync()
-            {
-                throw new System.NotImplementedException();
-            }
-
-            public Task<QueryResponse<JobResponse>> GetNextAsJobResponseAsync(QueryOptions options)
-            {
-                throw new System.NotImplementedException();
-            }
-
-            public Task<IEnumerable<string>> GetNextAsJsonAsync()
-            {
-                throw new System.NotImplementedException();
-            }
-
-            public Task<QueryResponse<string>> GetNextAsJsonAsync(QueryOptions options)
-            {
-                throw new System.NotImplementedException();
-            }
-
-            public bool HasMoreResults { get; set; }
         }
     }
 }

--- a/iothub-manager/Services.Test/helpers/ResultQuery.cs
+++ b/iothub-manager/Services.Test/helpers/ResultQuery.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.Devices;
+using Microsoft.Azure.Devices.Shared;
+
+namespace Services.Test.helpers
+{
+    public class ResultQuery : IQuery
+    {
+        private const string DEVICE_ID_KEY = "DeviceId";
+        private readonly List<Twin> results;
+        private readonly List<string> deviceQueryResults;
+
+        public ResultQuery(int numResults)
+        {
+            this.results = new List<Twin>();
+            this.deviceQueryResults = new List<string>();
+            for (int i = 0; i < numResults; i++)
+            {
+                this.results.Add(ResultQuery.CreateTestTwin(i));
+                this.deviceQueryResults.Add("{" + $"'{DEVICE_ID_KEY}':'device{i}'" + "}");
+                this.HasMoreResults = true;
+            }
+        }
+        public Task<IEnumerable<Twin>> GetNextAsTwinAsync()
+        {
+            this.HasMoreResults = false;
+            return Task.FromResult<IEnumerable<Twin>>(this.results);
+        }
+
+        public Task<QueryResponse<Twin>> GetNextAsTwinAsync(QueryOptions options)
+        {
+            this.HasMoreResults = false;
+            QueryResponse<Twin> resultResponse;
+
+            if (string.IsNullOrEmpty(options.ContinuationToken))
+            {
+                resultResponse = new QueryResponse<Twin>(this.results, "continuationToken");
+            }
+            else
+            {
+                var index = int.Parse(options.ContinuationToken);
+                var count = this.results.Count - index;
+
+                var continuedResults = new List<Twin>();
+                if (index < count)
+                {
+                    continuedResults = this.results.GetRange(index, count);
+                }
+                resultResponse = new QueryResponse<Twin>(continuedResults, "continuationToken");
+            }
+
+            return Task.FromResult(resultResponse);
+        }
+
+        public Task<IEnumerable<DeviceJob>> GetNextAsDeviceJobAsync()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<QueryResponse<DeviceJob>> GetNextAsDeviceJobAsync(QueryOptions options)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<IEnumerable<JobResponse>> GetNextAsJobResponseAsync()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<QueryResponse<JobResponse>> GetNextAsJobResponseAsync(QueryOptions options)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<IEnumerable<string>> GetNextAsJsonAsync()
+        {
+            this.HasMoreResults = false;
+            return Task.FromResult(deviceQueryResults.AsEnumerable());
+        }
+
+        public Task<QueryResponse<string>> GetNextAsJsonAsync(QueryOptions options)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool HasMoreResults { get; set; }
+
+        private static Twin CreateTestTwin(int valueToReport)
+        {
+            var twin = new Twin()
+            {
+                Properties = new TwinProperties()
+            };
+            twin.Properties.Reported = new TwinCollection("{\"test\":\"value" + valueToReport + "\"}");
+            twin.Properties.Desired = new TwinCollection("{\"test\":\"value" + valueToReport + "\"}");
+            return twin;
+        }
+    }
+}

--- a/iothub-manager/Services/Deployments.cs
+++ b/iothub-manager/Services/Deployments.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.Services
         private const string PACKAGE_ID_PARAM = "packageId";
         private const string PRIORITY_PARAM = "priority";
         private const string DEVICE_ID_KEY = "DeviceId";
+        private const string EDGE_MANIFEST_SCHEMA = "schemaVersion";
 
         private const string APPLIED_DEVICES_QUERY =
             "select deviceId from devices.modules where moduleId = '$edgeAgent'" + 
@@ -194,7 +195,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.Services
             {
                 DeploymentMetrics =
                 {
-                    DeviceWithStatus = includeDeviceStatus ? this.GetDeviceStatuses(deploymentId) : null
+                    DeviceStatuses = includeDeviceStatus ? this.GetDeviceStatuses(deploymentId) : null
                 }
             };
         }
@@ -222,11 +223,11 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.Services
             var edgeConfiguration = new Configuration(deploymentId);
 
             // TODO: Remove workaround for .net sdk issue which doesn't handle null schemaVersion
-            var schemaVersion = JToken.Parse(package.Content)["schemaVersion"];
+            var schemaVersion = JToken.Parse(package.Content)[EDGE_MANIFEST_SCHEMA];
             if (schemaVersion == null)
             {
                 var packageJson = JToken.Parse(package.Content);
-                packageJson["schemaVersion"] = "1.0";
+                packageJson[EDGE_MANIFEST_SCHEMA] = "1.0";
                 package.Content = packageJson.ToString();
             }
             var packageEdgeConfiguration = JsonConvert.DeserializeObject<Configuration>(package.Content);

--- a/iothub-manager/Services/Models/DeploymentMetrics.cs
+++ b/iothub-manager/Services/Models/DeploymentMetrics.cs
@@ -11,10 +11,12 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.Services.Models
     public class DeploymentMetrics
     {
         public IDictionary<string, long> Metrics { get; set; }
+        public IDictionary<string, DeploymentStatus> DeviceWithStatus { get; set; }
 
         public DeploymentMetrics(ConfigurationMetrics systemMetrics, ConfigurationMetrics customMetrics)
         {
             this.Metrics = new Dictionary<string, long>();
+            this.DeviceWithStatus = new Dictionary<string, DeploymentStatus>();
 
             if (systemMetrics?.Results?.Count > 0)
             {

--- a/iothub-manager/Services/Models/DeploymentMetrics.cs
+++ b/iothub-manager/Services/Models/DeploymentMetrics.cs
@@ -11,12 +11,12 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.Services.Models
     public class DeploymentMetrics
     {
         public IDictionary<string, long> Metrics { get; set; }
-        public IDictionary<string, DeploymentStatus> DeviceWithStatus { get; set; }
+        public IDictionary<string, DeploymentStatus> DeviceStatuses { get; set; }
 
         public DeploymentMetrics(ConfigurationMetrics systemMetrics, ConfigurationMetrics customMetrics)
         {
             this.Metrics = new Dictionary<string, long>();
-            this.DeviceWithStatus = new Dictionary<string, DeploymentStatus>();
+            this.DeviceStatuses = new Dictionary<string, DeploymentStatus>();
 
             if (systemMetrics?.Results?.Count > 0)
             {

--- a/iothub-manager/WebService.Test/v1/Controllers/DeploymentsControllerTest.cs
+++ b/iothub-manager/WebService.Test/v1/Controllers/DeploymentsControllerTest.cs
@@ -34,7 +34,7 @@ namespace WebService.Test.v1.Controllers
         public async Task GetDeploymentTest()
         {
             // Arrange
-            this.deploymentsMock.Setup(x => x.GetAsync(DEPLOYMENT_ID)).ReturnsAsync(new DeploymentServiceModel()
+            this.deploymentsMock.Setup(x => x.GetAsync(DEPLOYMENT_ID, false)).ReturnsAsync(new DeploymentServiceModel()
             {
                 Name = DEPLOYMENT_NAME,
                 DeviceGroupId = DEVICE_GROUP_ID,

--- a/iothub-manager/WebService/Properties/launchSettings.json
+++ b/iothub-manager/WebService/Properties/launchSettings.json
@@ -15,7 +15,8 @@
       "environmentVariables": {
         "PCS_AUTH_WEBSERVICE_URL" : "http://localhost:9001/v1",
         "PCS_IOTHUB_CONNSTRING": "$(PCS_IOTHUB_CONNSTRING)",
-        "PCS_STORAGEADAPTER_WEBSERVICE_URL": "http://localhost:9022/v1"
+        "PCS_STORAGEADAPTER_WEBSERVICE_URL": "http://localhost:9022/v1",
+        "PCS_CONFIG_WEBSERVICE_URL": "http://localhost:9005/v1"
       }
     },
     "WebService": {
@@ -25,7 +26,8 @@
       "environmentVariables": {
         "PCS_AUTH_WEBSERVICE_URL": "http://localhost:9001/v1",
         "PCS_IOTHUB_CONNSTRING": "$(PCS_IOTHUB_CONNSTRING)",
-        "PCS_STORAGEADAPTER_WEBSERVICE_URL": "http://localhost:9022/v1"
+        "PCS_STORAGEADAPTER_WEBSERVICE_URL": "http://localhost:9022/v1",
+        "PCS_CONFIG_WEBSERVICE_URL": "http://localhost:9005/v1"
       },
       "applicationUrl": "http://localhost:9002/v1/status"
     }

--- a/iothub-manager/WebService/appsettings.ini
+++ b/iothub-manager/WebService/appsettings.ini
@@ -10,6 +10,9 @@ TTL = 3600
 ; How long, in seconds, to timeout before trying to build device properties again
 rebuild_timeout = 20
 
+[ConfigService]
+webservice_url = "${PCS_CONFIG_WEBSERVICE_URL}"
+
 [StorageAdapterService]
 webservice_url = "${PCS_STORAGEADAPTER_WEBSERVICE_URL}"
 

--- a/iothub-manager/WebService/appsettings.ini
+++ b/iothub-manager/WebService/appsettings.ini
@@ -10,9 +10,6 @@ TTL = 3600
 ; How long, in seconds, to timeout before trying to build device properties again
 rebuild_timeout = 20
 
-[ConfigService]
-webservice_url = "${PCS_CONFIG_WEBSERVICE_URL}"
-
 [StorageAdapterService]
 webservice_url = "${PCS_STORAGEADAPTER_WEBSERVICE_URL}"
 

--- a/iothub-manager/WebService/appsettings.ini
+++ b/iothub-manager/WebService/appsettings.ini
@@ -16,6 +16,9 @@ webservice_url = "${PCS_STORAGEADAPTER_WEBSERVICE_URL}"
 [UserManagementService]
 webservice_url = "${PCS_AUTH_WEBSERVICE_URL}"
 
+[ConfigService]
+webservice_url = "${PCS_CONFIG_WEBSERVICE_URL}"
+
 [IothubManagerService:ClientAuth]
 ;; Current auth type, only "JWT" is currently supported.
 auth_type="JWT"

--- a/iothub-manager/WebService/v1/Controllers/DeploymentsController.cs
+++ b/iothub-manager/WebService/v1/Controllers/DeploymentsController.cs
@@ -57,11 +57,12 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Controllers
 
         /// <summary>Get one deployment</summary>
         /// <param name="id">Deployment id</param>
+        /// <param name="includeDeviceStatus">Whether to retrieve additional details regarding device status</param>
         /// <returns>Deployment information with metrics</returns>
         [HttpGet("{id}")]
-        public async Task<DeploymentApiModel> GetAsync(string id)
+        public async Task<DeploymentApiModel> GetAsync(string id, [FromQuery] bool includeDeviceStatus = false)
         {
-            return new DeploymentApiModel(await this.deployments.GetAsync(id));
+            return new DeploymentApiModel(await this.deployments.GetAsync(id, includeDeviceStatus));
         }
 
         [HttpDelete("{id}")]

--- a/iothub-manager/WebService/v1/Controllers/DeploymentsController.cs
+++ b/iothub-manager/WebService/v1/Controllers/DeploymentsController.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Controllers
         /// <param name="deployment">Deployment information</param>
         /// <returns>Deployment information and initial success metrics</returns>
         [HttpPost]
+        [Authorize("CreateDeployments")]
         public async Task<DeploymentApiModel> PostAsync([FromBody] DeploymentApiModel deployment)
         {
             if (string.IsNullOrWhiteSpace(deployment.DeviceGroupId))
@@ -66,6 +67,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Controllers
         }
 
         [HttpDelete("{id}")]
+        [Authorize("DeleteDeployments")]
         public async Task DeleteAsync(string id)
         {
             await this.deployments.DeleteAsync(id);

--- a/iothub-manager/WebService/v1/Models/DeploymentApiModel.cs
+++ b/iothub-manager/WebService/v1/Models/DeploymentApiModel.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Models
             this.Type = serviceModel.Type;
             this.Metrics = new DeploymentMetricsApiModel(serviceModel.DeploymentMetrics)
             {
-                DeviceStatuses = serviceModel.DeploymentMetrics.DeviceWithStatus
+                DeviceStatuses = serviceModel.DeploymentMetrics?.DeviceWithStatus
             };
         }
 

--- a/iothub-manager/WebService/v1/Models/DeploymentApiModel.cs
+++ b/iothub-manager/WebService/v1/Models/DeploymentApiModel.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Models
             this.Type = serviceModel.Type;
             this.Metrics = new DeploymentMetricsApiModel(serviceModel.DeploymentMetrics)
             {
-                DeviceStatuses = serviceModel.DeploymentMetrics?.DeviceWithStatus
+                DeviceStatuses = serviceModel.DeploymentMetrics?.DeviceStatuses
             };
         }
 

--- a/iothub-manager/WebService/v1/Models/DeploymentApiModel.cs
+++ b/iothub-manager/WebService/v1/Models/DeploymentApiModel.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
+using Microsoft.Azure.IoTSolutions.IotHubManager.Services;
 using Microsoft.Azure.IoTSolutions.IotHubManager.Services.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -47,7 +49,26 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Models
             this.PackageId = serviceModel.PackageId;
             this.Priority = serviceModel.Priority;
             this.Type = serviceModel.Type;
-            this.Metrics = new DeploymentMetricsApiModel(serviceModel.DeploymentMetrics);
+            this.Metrics = new DeploymentMetricsApiModel(serviceModel.DeploymentMetrics)
+            {
+                DeviceStatuses = serviceModel.DeploymentMetrics.DeviceWithStatus
+            };
+        }
+
+        public DeploymentApiModel(DeploymentServiceModel serviceModel,
+                                  IDictionary<string, DeploymentStatus> deviceStatuses)
+        {
+            this.CreatedDateTimeUtc = serviceModel.CreatedDateTimeUtc;
+            this.DeploymentId = serviceModel.Id;
+            this.DeviceGroupId = serviceModel.DeviceGroupId;
+            this.Name = serviceModel.Name;
+            this.PackageId = serviceModel.PackageId;
+            this.Priority = serviceModel.Priority;
+            this.Type = serviceModel.Type;
+            this.Metrics = new DeploymentMetricsApiModel(serviceModel.DeploymentMetrics)
+            {
+                DeviceStatuses = deviceStatuses
+            };
         }
 
         public DeploymentServiceModel ToServiceModel()

--- a/iothub-manager/WebService/v1/Models/DeploymentMetricsApiModel.cs
+++ b/iothub-manager/WebService/v1/Models/DeploymentMetricsApiModel.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using Microsoft.Azure.IoTSolutions.IotHubManager.Services;
 using Microsoft.Azure.IoTSolutions.IotHubManager.Services.Models;
 using Newtonsoft.Json;
 
@@ -24,6 +25,9 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Models
 
         [JsonProperty(PropertyName = "TargetedCount")]
         public long TargetedCount { get; set; }
+
+        [JsonProperty(PropertyName = "DeviceStatuses")]
+        public IDictionary<string, DeploymentStatus> DeviceStatuses { get; set; }
 
         public DeploymentMetricsApiModel()
         {


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
As part of edge deployments it is helpful to know the status of each device per device Id. This however, is an expensive call and therefore made optional with the inclusion of a query parameter ?includeDeviceStatus=true

# Motivation for the change
Adds the ability to show status for each device.
