### PR TITLE
Add POST Version of Telemetry Queries

### DIFF
--- a/device-telemetry/WebService.Test/Controllers/AlarmsByRuleControllerTest.cs
+++ b/device-telemetry/WebService.Test/Controllers/AlarmsByRuleControllerTest.cs
@@ -76,7 +76,7 @@ namespace WebService.Test.Controllers
         public void ProvideAlarmsByRuleResult()
         {
             // Act
-            var response = this.controller.ListAsync(null, null, "asc", null, null, null);
+            var response = this.controller.GetAsync(null, null, "asc", null, null, null);
 
             // Assert
             Assert.NotEmpty(response.Result.Metadata);

--- a/device-telemetry/WebService/v1/Controllers/AlarmsByRuleController.cs
+++ b/device-telemetry/WebService/v1/Controllers/AlarmsByRuleController.cs
@@ -51,6 +51,22 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
             return await this.GetAlarmCountByRuleHelper(from, to, order, skip, limit, deviceIds);
         }
 
+        [HttpPost]
+        public async Task<AlarmByRuleListApiModel> PostAsync([FromBody] QueryApiModel body)
+        {
+            string[] deviceIds = body.Devices == null
+                ? new string[0]
+                : body.Devices.ToArray();
+
+            return await this.GetAlarmCountByRuleHelper(
+                body.From,
+                body.To,
+                body.Order,
+                body.Skip,
+                body.Limit,
+                deviceIds);
+        }
+
         [HttpGet("{id}")]
         public AlarmListByRuleApiModel Get(
             [FromRoute] string id,
@@ -76,28 +92,11 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
             [FromBody] QueryApiModel body)
         {
             string[] deviceIds = body.Devices == null
-                ? new string[0] 
+                ? new string[0]
                 : body.Devices.ToArray();
 
             return this.GetAlarmListByRuleHelper(
                 id,
-                body.From, 
-                body.To, 
-                body.Order, 
-                body.Skip, 
-                body.Limit, 
-                deviceIds);
-        }
-
-        [HttpPost]
-        public async Task<AlarmByRuleListApiModel> PostAsync(
-            [FromBody] QueryApiModel body)
-        {
-            string[] deviceIds = body.Devices == null
-                ? new string[0]
-                : body.Devices.ToArray();
-
-            return await this.GetAlarmCountByRuleHelper(
                 body.From,
                 body.To,
                 body.Order,
@@ -105,7 +104,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
                 body.Limit,
                 deviceIds);
         }
-        
+
         private async Task<AlarmByRuleListApiModel> GetAlarmCountByRuleHelper(
             string from,
             string to,

--- a/device-telemetry/WebService/v1/Controllers/AlarmsByRuleController.cs
+++ b/device-telemetry/WebService/v1/Controllers/AlarmsByRuleController.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
     [Route(Version.PATH + "/[controller]"), TypeFilter(typeof(ExceptionsFilterAttribute))]
     public class AlarmsByRuleController : Controller
     {
-        private const int DEVICE_LIMIT = 200;
+        private const int DEVICE_LIMIT = 1000;
 
         private readonly IAlarms alarmService;
         private readonly IRules ruleService;
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
         }
 
         [HttpGet]
-        public async Task<AlarmByRuleListApiModel> ListAsync(
+        public async Task<AlarmByRuleListApiModel> GetAsync(
             [FromQuery] string from,
             [FromQuery] string to,
             [FromQuery] string order,
@@ -42,39 +42,13 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
             [FromQuery] int? limit,
             [FromQuery] string devices)
         {
-            DateTimeOffset? fromDate = DateHelper.ParseDate(from);
-            DateTimeOffset? toDate = DateHelper.ParseDate(to);
-
-            if (order == null) order = "asc";
-            if (skip == null) skip = 0;
-            if (limit == null) limit = 1000;
-
-            /* TODO: move this logic to the storage engine, depending on the
-             * storage type the limit will be different. 200 is CosmosDb
-             * limit for the IN clause.
-             */
             string[] deviceIds = new string[0];
             if (!string.IsNullOrEmpty(devices))
             {
                 deviceIds = devices.Split(',');
             }
 
-            if (deviceIds.Length > DEVICE_LIMIT)
-            {
-                this.log.Warn("The client requested too many devices", () => new { devices.Length });
-                throw new BadRequestException("The number of devices cannot exceed 200");
-            }
-
-            List<AlarmCountByRule> alarmsList 
-                = await this.ruleService.GetAlarmCountForListAsync(
-                fromDate,
-                toDate,
-                order,
-                skip.Value,
-                limit.Value,
-                deviceIds);
-
-            return new AlarmByRuleListApiModel(alarmsList);
+            return await this.GetAlarmCountByRuleHelper(from, to, order, skip, limit, deviceIds);
         }
 
         [HttpGet("{id}")]
@@ -87,6 +61,59 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
             [FromQuery] int? limit,
             [FromQuery] string devices)
         {
+            string[] deviceIds = new string[0];
+            if (!string.IsNullOrEmpty(devices))
+            {
+                deviceIds = devices.Split(',');
+            }
+
+            return this.GetAlarmListByRuleHelper(id, from, to, order, skip, limit, deviceIds);
+        }
+
+        [HttpPost("{id}")]
+        public AlarmListByRuleApiModel Post(
+            [FromRoute] string id,
+            [FromBody] QueryApiModel body)
+        {
+            string[] deviceIds = body.Devices == null
+                ? new string[0] 
+                : body.Devices.ToArray();
+
+            return this.GetAlarmListByRuleHelper(
+                id,
+                body.From, 
+                body.To, 
+                body.Order, 
+                body.Skip, 
+                body.Limit, 
+                deviceIds);
+        }
+
+        [HttpPost]
+        public async Task<AlarmByRuleListApiModel> PostAsync(
+            [FromBody] QueryApiModel body)
+        {
+            string[] deviceIds = body.Devices == null
+                ? new string[0]
+                : body.Devices.ToArray();
+
+            return await this.GetAlarmCountByRuleHelper(
+                body.From,
+                body.To,
+                body.Order,
+                body.Skip,
+                body.Limit,
+                deviceIds);
+        }
+        
+        private async Task<AlarmByRuleListApiModel> GetAlarmCountByRuleHelper(
+            string from,
+            string to,
+            string order,
+            int? skip,
+            int? limit,
+            string[] deviceIds)
+        {
             DateTimeOffset? fromDate = DateHelper.ParseDate(from);
             DateTimeOffset? toDate = DateHelper.ParseDate(to);
 
@@ -95,18 +122,50 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
             if (limit == null) limit = 1000;
 
             /* TODO: move this logic to the storage engine, depending on the
-             * storage type the limit will be different. 200 is CosmosDb
+             * storage type the limit will be different. DEVICE_LIMIT is CosmosDb
              * limit for the IN clause.
              */
-            string[] deviceIds = new string[0];
-            if (!string.IsNullOrEmpty(devices))
-            {
-                deviceIds = devices.Split(',');
-            }
-
             if (deviceIds.Length > DEVICE_LIMIT)
             {
-                this.log.Warn("The client requested too many devices", () => new { devices.Length });
+                this.log.Warn("The client requested too many devices", () => new { deviceIds.Length });
+                throw new BadRequestException("The number of devices cannot exceed " + DEVICE_LIMIT);
+            }
+
+            List<AlarmCountByRule> alarmsList
+                = await this.ruleService.GetAlarmCountForListAsync(
+                    fromDate,
+                    toDate,
+                    order,
+                    skip.Value,
+                    limit.Value,
+                    deviceIds);
+
+            return new AlarmByRuleListApiModel(alarmsList);
+        }
+
+        private AlarmListByRuleApiModel GetAlarmListByRuleHelper(
+            string id,
+            string from,
+            string to,
+            string order,
+            int? skip,
+            int? limit,
+            string[] deviceIds)
+        {
+            DateTimeOffset? fromDate = DateHelper.ParseDate(from);
+            DateTimeOffset? toDate = DateHelper.ParseDate(to);
+
+            if (order == null) order = "asc";
+            if (skip == null) skip = 0;
+            if (limit == null) limit = 1000;
+
+            /* TODO: move this logic to the storage engine, depending on the
+             * storage type the limit will be different. DEVICE_LIMIT is CosmosDb
+             * limit for the IN clause.
+             */
+            if (deviceIds.Length > DEVICE_LIMIT)
+            {
+                this.log.Warn("The client requested too many devices", () => new { deviceIds.Length });
                 throw new BadRequestException("The number of devices cannot exceed 200");
             }
 

--- a/device-telemetry/WebService/v1/Controllers/AlarmsByRuleController.cs
+++ b/device-telemetry/WebService/v1/Controllers/AlarmsByRuleController.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.Devices;
 using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services;
 using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Models;

--- a/device-telemetry/WebService/v1/Controllers/AlarmsByRuleController.cs
+++ b/device-telemetry/WebService/v1/Controllers/AlarmsByRuleController.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Devices;
 using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services;
 using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Models;
@@ -165,7 +166,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
             if (deviceIds.Length > DEVICE_LIMIT)
             {
                 this.log.Warn("The client requested too many devices", () => new { deviceIds.Length });
-                throw new BadRequestException("The number of devices cannot exceed 200");
+                throw new BadRequestException("The number of devices cannot exceed " + DEVICE_LIMIT);
             }
 
             List<Alarm> alarmsList = this.alarmService.ListByRule(

--- a/device-telemetry/WebService/v1/Controllers/MessagesController.cs
+++ b/device-telemetry/WebService/v1/Controllers/MessagesController.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services;
@@ -49,8 +48,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
         }
 
         [HttpPost]
-        public async Task<MessageListApiModel> PostAsync(
-            [FromBody] QueryApiModel body)
+        public async Task<MessageListApiModel> PostAsync([FromBody] QueryApiModel body)
         {
             string[] deviceIds = body.Devices == null
                 ? new string[0]

--- a/device-telemetry/WebService/v1/Controllers/MessagesController.cs
+++ b/device-telemetry/WebService/v1/Controllers/MessagesController.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services;
@@ -16,6 +17,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
     [Route(Version.PATH + "/[controller]"), TypeFilter(typeof(ExceptionsFilterAttribute))]
     public sealed class MessagesController : Controller
     {
+        private const int DEVICE_LIMIT = 1000;
+
         private readonly IMessages messageService;
         private readonly ILogger log;
 
@@ -36,6 +39,34 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
             [FromQuery] int? limit,
             [FromQuery] string devices)
         {
+            string[] deviceIds = new string[0];
+            if (devices != null)
+            {
+                deviceIds = devices.Split(',');
+            }
+
+            return await this.ListMessagesHelper(from, to, order, skip, limit, deviceIds);
+        }
+
+        [HttpPost]
+        public async Task<MessageListApiModel> PostAsync(
+            [FromBody] QueryApiModel body)
+        {
+            string[] deviceIds = body.Devices == null
+                ? new string[0]
+                : body.Devices.ToArray();
+
+            return await this.ListMessagesHelper(body.From, body.To, body.Order, body.Skip, body.Limit, deviceIds);
+        }
+
+        private async Task<MessageListApiModel> ListMessagesHelper(
+            string from,
+            string to,
+            string order,
+            int? skip,
+            int? limit,
+            string[] deviceIds)
+        {
             DateTimeOffset? fromDate = DateHelper.ParseDate(from);
             DateTimeOffset? toDate = DateHelper.ParseDate(to);
 
@@ -44,17 +75,12 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
             if (limit == null) limit = 1000;
 
             // TODO: move this logic to the storage engine, depending on the
-            // storage type the limit will be different. 200 is CosmosDb
+            // storage type the limit will be different. DEVICE_LIMIT is CosmosDb
             // limit for the IN clause.
-            string[] deviceIds = new string[0];
-            if (devices != null)
-            {
-                deviceIds = devices.Split(',');
-            }
-            if (deviceIds.Length > 200)
+            if (deviceIds.Length > DEVICE_LIMIT)
             {
                 this.log.Warn("The client requested too many devices: {}", () => new { deviceIds.Length });
-                throw new BadRequestException("The number of devices cannot exceed 200");
+                throw new BadRequestException("The number of devices cannot exceed " + DEVICE_LIMIT);
             }
 
             MessageList messageList = await this.messageService.ListAsync(

--- a/device-telemetry/WebService/v1/Models/QueryApiModel.cs
+++ b/device-telemetry/WebService/v1/Models/QueryApiModel.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Models
+{
+    public class QueryApiModel
+    {
+        [JsonProperty(PropertyName = "From")]
+        public string From { get; set; }
+
+        [JsonProperty(PropertyName = "To")]
+        public string To { get; set; }
+
+        [JsonProperty(PropertyName = "Order")]
+        public string Order { get; set; }
+
+        [JsonProperty(PropertyName = "Skip")]
+        public int? Skip { get; set; }
+
+        [JsonProperty(PropertyName = "Limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty(PropertyName = "Devices")]
+        public List<string> Devices { get; set; }
+
+        public QueryApiModel()
+        {
+            this.From = "";
+            this.To = "";
+            this.Order = null;
+            this.Skip = null;
+            this.Limit = null;
+            this.Devices = new List<string>();
+        }
+
+        public QueryApiModel(
+            string from,
+            string to,
+            string order,
+            int? skip,
+            int? limit,
+            List<string> devices)
+        {
+            this.From = from;
+            this.To = to;
+            this.Order = order;
+            this.Skip = skip;
+            this.Limit = limit;
+            this.Devices = devices;
+        }
+    }
+}


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [x] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
Add POST request versions of GET requests in telemetry service which require a list of device ids. These queries can get too long for a URL (> 2048 characters), which presents as a 404 error on the web ui. Therefore, we will update the web ui to use a POST request if the query is too long. Also increase limit for number of device ids in a query to 1000, because Cosmos DB has increased the IN clause limit.
Added post requests for:
-Get messages
-Get alarms by rule
-Get alarms by rule id
-Get list of alarms
# Motivation for the change
This is related to this issue: https://github.com/Azure/azure-iot-pcs-remote-monitoring-dotnet/issues/108
