### PR TITLE
Add extra error handling on package and deployment creation

### DIFF
--- a/config/Services.Test/StorageTest.cs
+++ b/config/Services.Test/StorageTest.cs
@@ -24,6 +24,69 @@ namespace Services.Test
         private readonly Storage storage;
         private readonly Random rand;
         private const string PACKAGES_COLLECTION_ID = "packages";
+        private const string TEST_PACKAGE_JSON =
+                @"{
+                    ""id"": ""tempid"",
+                    ""schemaVersion"": ""1.0"",
+                    ""content"": {
+                        ""modulesContent"": {
+                        ""$edgeAgent"": {
+                            ""properties.desired"": {
+                            ""schemaVersion"": ""1.0"",
+                            ""runtime"": {
+                                ""type"": ""docker"",
+                                ""settings"": {
+                                ""loggingOptions"": """",
+                                ""minDockerVersion"": ""v1.25""
+                                }
+                            },
+                            ""systemModules"": {
+                                ""edgeAgent"": {
+                                ""type"": ""docker"",
+                                ""settings"": {
+                                    ""image"": ""mcr.microsoft.com/azureiotedge-agent:1.0"",
+                                    ""createOptions"": ""{}""
+                                }
+                                },
+                                ""edgeHub"": {
+                                ""type"": ""docker"",
+                                ""settings"": {
+                                    ""image"": ""mcr.microsoft.com/azureiotedge-hub:1.0"",
+                                    ""createOptions"": ""{}""
+                                },
+                                ""status"": ""running"",
+                                ""restartPolicy"": ""always""
+                                }
+                            },
+                            ""modules"": {}
+                            }
+                        },
+                        ""$edgeHub"": {
+                            ""properties.desired"": {
+                            ""schemaVersion"": ""1.0"",
+                            ""routes"": {
+                                ""route"": ""FROM /messages/* INTO $upstream""
+                            },
+                            ""storeAndForwardConfiguration"": {
+                                ""timeToLiveSecs"": 7200
+                            }
+                            }
+                        }
+                        }
+                    },
+                    ""targetCondition"": ""*"",
+                    ""priority"": 30,
+                    ""labels"": {
+                        ""Name"": ""Test""
+                    },
+                    ""createdTimeUtc"": ""2018-08-20T18:05:55.482Z"",
+                    ""lastUpdatedTimeUtc"": ""2018-08-20T18:05:55.482Z"",
+                    ""etag"": null,
+                    ""metrics"": {
+                        ""results"": {},
+                        ""queries"": {}
+                    }
+                 }";
 
         public StorageTest()
         {
@@ -611,7 +674,7 @@ namespace Services.Test
                 Id = string.Empty,
                 Name = key,
                 Type = PackageType.EdgeManifest,
-                Content = "SomeContent"
+                Content = TEST_PACKAGE_JSON
             };
             var value = JsonConvert.SerializeObject(pkg);
 
@@ -629,6 +692,21 @@ namespace Services.Test
             Assert.Equal(pkg.Name, result.Name);
             Assert.Equal(pkg.Type, result.Type);
             Assert.Equal(pkg.Content, result.Content);
+        }
+
+        [Fact]
+        public async Task InvalidPackageThrowsTest()
+        {
+            var pkg = new Package
+            {
+                Id = string.Empty,
+                Name = "testpackage",
+                Type = PackageType.EdgeManifest,
+                Content = "InvalidPackage"
+            };
+
+            await Assert.ThrowsAsync<InvalidInputException>(async () => 
+                await this.storage.AddPackageAsync(pkg));
         }
 
         [Fact]

--- a/config/Services/Services.csproj
+++ b/config/Services/Services.csproj
@@ -18,6 +18,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.17.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/config/Services/Storage.cs
+++ b/config/Services/Storage.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Azure.Devices;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Exceptions;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.External;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Models;
@@ -184,6 +185,15 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services
 
         public async Task<Package> AddPackageAsync(Package package)
         {
+            try
+            {
+                JsonConvert.DeserializeObject<Configuration>(package.Content);
+            }
+            catch (Exception)
+            {
+                throw new InvalidInputException("Package provided is not a valid deployment manifest");
+            }
+
             package.DateCreated = DateTimeOffset.UtcNow.ToString(DATE_FORMAT);
             var value = JsonConvert.SerializeObject(package,
                                                     Formatting.Indented,

--- a/iothub-manager/Services/Deployments.cs
+++ b/iothub-manager/Services/Deployments.cs
@@ -120,6 +120,9 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.Services
             }
 
             var edgeConfiguration = this.CreateEdgeConfiguration(model);
+
+            // TODO: Add specific exception handling when exception types are exposed
+            // https://github.com/Azure/azure-iot-sdk-csharp/issues/649
             return new DeploymentServiceModel(await this.registry.AddConfigurationAsync(edgeConfiguration));
         }
 


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
Provides a bit of additional handling around uploading of a package. It verifies that the package content provided is able to deserialize into a proper deployment configuration object before saving it.

# Motivation for the change
It doesn't make sense to let a user upload a package if it will never succeed deployment. This adds the additional verification needed on upload.