### PR TITLE
Add optional labels in a deployment for package and device group name

### DIFF
--- a/iothub-manager/Services/Deployments.cs
+++ b/iothub-manager/Services/Deployments.cs
@@ -33,14 +33,19 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.Services
     public class Deployments : IDeployments
     {
         private const int MAX_DEPLOYMENTS = 20;
+
         private const string DEPLOYMENT_NAME_LABEL = "Name";
         private const string DEPLOYMENT_GROUP_ID_LABEL = "DeviceGroupId";
+        private const string DEPLOYMENT_GROUP_NAME_LABEL = "DeviceGroupName";
+        private const string DEPLOYMENT_PACKAGE_NAME_LABEL = "PackageName";
         private const string RM_CREATED_LABEL = "RMDeployment";
+
         private const string DEVICE_GROUP_ID_PARAM = "deviceGroupId";
         private const string DEVICE_GROUP_QUERY_PARAM = "deviceGroupQuery";
         private const string NAME_PARAM = "name";
         private const string PACKAGE_CONTENT_PARAM = "packageContent";
         private const string PRIORITY_PARAM = "priority";
+
         private const string DEVICE_ID_KEY = "DeviceId";
         private const string EDGE_MANIFEST_SCHEMA = "schemaVersion";
 
@@ -223,9 +228,21 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.Services
             {
                 edgeConfiguration.Labels = new Dictionary<string, string>();
             }
+
+            // Required labels
             edgeConfiguration.Labels.Add(DEPLOYMENT_NAME_LABEL, model.Name);
             edgeConfiguration.Labels.Add(DEPLOYMENT_GROUP_ID_LABEL, model.DeviceGroupId);
             edgeConfiguration.Labels.Add(RM_CREATED_LABEL, bool.TrueString);
+
+            // Add optional labels
+            if (model.DeviceGroupName != null)
+            {
+                edgeConfiguration.Labels.Add(DEPLOYMENT_GROUP_NAME_LABEL, model.DeviceGroupName);
+            }
+            if (model.PackageName != null)
+            {
+                edgeConfiguration.Labels.Add(DEPLOYMENT_PACKAGE_NAME_LABEL, model.PackageName);
+            }
 
             return edgeConfiguration;
         }

--- a/iothub-manager/Services/Models/DeploymentServiceModel.cs
+++ b/iothub-manager/Services/Models/DeploymentServiceModel.cs
@@ -9,15 +9,19 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.Services.Models
     {
         private const string DEPLOYMENT_NAME_LABEL = "Name";
         private const string DEPLOYMENT_GROUP_ID_LABEL = "DeviceGroupId";
+        private const string DEPLOYMENT_GROUP_NAME_LABEL = "DeviceGroupName";
+        private const string DEPLOYMENT_PACKAGE_NAME_LABEL = "PackageName";
         private const string RM_CREATED_LABEL = "RMDeployment";
 
         public DateTime CreatedDateTimeUtc { get; set; }
         public string Id { get; set; }
         public DeploymentMetrics DeploymentMetrics { get; set; }
         public string DeviceGroupId { get; set; }
+        public string DeviceGroupName { get; set; }
         public string DeviceGroupQuery { get; set; }
         public string Name {get; set; }
         public string PackageContent { get; set; }
+        public string PackageName { get; set; }
         public int Priority { get; set; }
         public DeploymentType Type { get; set; }
 
@@ -40,6 +44,17 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.Services.Models
             this.Name = config.Labels[DEPLOYMENT_NAME_LABEL];
             this.CreatedDateTimeUtc = config.CreatedTimeUtc;
             this.DeviceGroupId = config.Labels[DEPLOYMENT_GROUP_ID_LABEL];
+
+            if (config.Labels.ContainsKey(DEPLOYMENT_GROUP_NAME_LABEL))
+            {
+                this.DeviceGroupName = config.Labels[DEPLOYMENT_GROUP_NAME_LABEL];
+            }
+
+            if (config.Labels.ContainsKey(DEPLOYMENT_PACKAGE_NAME_LABEL))
+            {
+                this.PackageName = config.Labels[DEPLOYMENT_PACKAGE_NAME_LABEL];
+            }
+
             this.Priority = config.Priority;
             this.Type = DeploymentType.EdgeManifest;
 

--- a/iothub-manager/WebService.Test/v1/Controllers/DeploymentsControllerTest.cs
+++ b/iothub-manager/WebService.Test/v1/Controllers/DeploymentsControllerTest.cs
@@ -20,8 +20,10 @@ namespace WebService.Test.v1.Controllers
         private readonly Mock<IDeployments> deploymentsMock;
         private const string DEPLOYMENT_NAME = "depname";
         private const string DEVICE_GROUP_ID = "dvcGroupId";
+        private const string DEVICE_GROUP_NAME = "dvcGroupName";
         private const string DEVICE_GROUP_QUERY = "dvcGroupQuery";
         private const string PACKAGE_CONTENT = "{}";
+        private const string PACKAGE_NAME = "packageName";
         private const string DEPLOYMENT_ID = "dvcGroupId-packageId";
         private const int PRIORITY = 10;
 
@@ -39,6 +41,40 @@ namespace WebService.Test.v1.Controllers
             {
                 Name = DEPLOYMENT_NAME,
                 DeviceGroupId = DEVICE_GROUP_ID,
+                DeviceGroupName = DEVICE_GROUP_NAME,
+                DeviceGroupQuery = DEVICE_GROUP_QUERY,
+                PackageContent = PACKAGE_CONTENT,
+                PackageName = PACKAGE_NAME,
+                Priority = PRIORITY,
+                Id = DEPLOYMENT_ID,
+                Type = DeploymentType.EdgeManifest,
+                CreatedDateTimeUtc = DateTime.UtcNow
+            });
+
+            // Act
+            var result = await this.deploymentsController.GetAsync(DEPLOYMENT_ID);
+
+            // Assert
+            Assert.Equal(DEPLOYMENT_ID, result.DeploymentId);
+            Assert.Equal(DEPLOYMENT_NAME, result.Name);
+            Assert.Equal(PACKAGE_CONTENT, result.PackageContent);
+            Assert.Equal(PACKAGE_NAME, result.PackageName);
+            Assert.Equal(DEVICE_GROUP_ID, result.DeviceGroupId);
+            Assert.Equal(DEVICE_GROUP_NAME, result.DeviceGroupName);
+            Assert.Equal(PRIORITY, result.Priority);
+            Assert.Equal(DeploymentType.EdgeManifest, result.Type);
+            Assert.True((DateTimeOffset.UtcNow - result.CreatedDateTimeUtc).TotalSeconds < 5);
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public async Task VerifyGroupAndPackageNameLabelsTest()
+        {
+            // Arrange
+            this.deploymentsMock.Setup(x => x.GetAsync(DEPLOYMENT_ID, false)).ReturnsAsync(new DeploymentServiceModel()
+            {
+                Name = DEPLOYMENT_NAME,
+                DeviceGroupId = DEVICE_GROUP_ID,
+                DeviceGroupName = DEVICE_GROUP_NAME,
                 DeviceGroupQuery = DEVICE_GROUP_QUERY,
                 PackageContent = PACKAGE_CONTENT,
                 Priority = PRIORITY,

--- a/iothub-manager/WebService/v1/Models/DeploymentApiModel.cs
+++ b/iothub-manager/WebService/v1/Models/DeploymentApiModel.cs
@@ -23,12 +23,18 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Models
         [JsonProperty(PropertyName = "DeviceGroupId")]
         public string DeviceGroupId { get; set; }
 
+        [JsonProperty(PropertyName = "DeviceGroupName")]
+        public string DeviceGroupName { get; set; }
+
         [JsonProperty(PropertyName = "DeviceGroupQuery")]
         public string DeviceGroupQuery { get; set; }
 
         [JsonProperty(PropertyName = "PackageContent")]
         public string PackageContent { get; set; }
-        
+
+        [JsonProperty(PropertyName = "PackageName")]
+        public string PackageName { get; set; }
+
         [JsonProperty(PropertyName = "Priority")]
         public int Priority { get; set; }
 
@@ -48,9 +54,11 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Models
             this.CreatedDateTimeUtc = serviceModel.CreatedDateTimeUtc;
             this.DeploymentId = serviceModel.Id;
             this.DeviceGroupId = serviceModel.DeviceGroupId;
+            this.DeviceGroupName = serviceModel.DeviceGroupName;
             this.DeviceGroupQuery = serviceModel.DeviceGroupQuery;
             this.Name = serviceModel.Name;
             this.PackageContent = serviceModel.PackageContent;
+            this.PackageName = serviceModel.PackageName;
             this.Priority = serviceModel.Priority;
             this.Type = serviceModel.Type;
             this.Metrics = new DeploymentMetricsApiModel(serviceModel.DeploymentMetrics)
@@ -77,12 +85,14 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Models
         public DeploymentServiceModel ToServiceModel()
         {
             return new DeploymentServiceModel() {
-                 DeviceGroupId = this.DeviceGroupId,
-                 DeviceGroupQuery = this.DeviceGroupQuery,
-                 Name = this.Name,
-                 PackageContent = this.PackageContent,
-                 Priority = this.Priority,
-                 Type = this.Type
+                DeviceGroupId = this.DeviceGroupId,
+                DeviceGroupName = this.DeviceGroupName,
+                DeviceGroupQuery = this.DeviceGroupQuery,
+                Name = this.Name,
+                PackageContent = this.PackageContent,
+                PackageName = this.PackageName,
+                Priority = this.Priority,
+                Type = this.Type
             };
         }
     }


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [x] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (Will do so when merging final feature).

# Description of the change
Adds additional labels for quick lookup of the device group name and package name to help reflect how the deployment was created in our UI.

# Motivation for the change
This helps because a package / device group could be deleted making look up of the package name impossible in the future.
