### PR TITLE
Increase timeout in TelemetryRulesAgent

### DIFF
--- a/asa-manager/TelemetryRulesAgent/Agent.cs
+++ b/asa-manager/TelemetryRulesAgent/Agent.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Azure.IoTSolutions.AsaManager.TelemetryRulesAgent
 
     public class Agent : IAgent
     {
-        // Check if rules have been modified every 10 seconds
-        // (not too frequently, but frequently enough to provide a good UX)
-        private const int CHECK_INTERVAL_MSECS = 10000;
+        // Check if rules have been modified every 60 seconds
+        // Can only write reference data at most once a minute, or may lose changes
+        private const int CHECK_INTERVAL_MSECS = 60000;
 
         private readonly ILogger log;
         private readonly IRules rulesService;


### PR DESCRIPTION


# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
<!-- Please provide enough information so others can review your pull request -->
ASA only reads reference data once per minute. This means if we write data to the same file more than once in a minute, ASA may not pick up the second write, and will never see a rule update. Previoulsy our timeout was 10 seconds to write to ASA for rules. Increase this timeout to 60 seconds to ensure ASA always reads our updates.

# Motivation for the change
<!-- Please explain the motivation for making this change -->
...
