### PR TITLE
Only serialize non-empty actions in reference data

### DIFF
--- a/asa-manager/TelemetryRulesAgent/Models/AsaRefDataRule.cs
+++ b/asa-manager/TelemetryRulesAgent/Models/AsaRefDataRule.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.IoTSolutions.AsaManager.TelemetryRulesAgent.Models
         [JsonProperty("Fields")]
         public List<string> Fields { get; set; }
 
-        [JsonProperty("Actions")]
+        [JsonProperty("Actions", NullValueHandling = NullValueHandling.Ignore)]
         public List<IActionApiModel> Actions { get; set; }
 
         [JsonProperty("__rulefilterjs")]
@@ -124,7 +124,6 @@ namespace Microsoft.Azure.IoTSolutions.AsaManager.TelemetryRulesAgent.Models
         {
             this.conditions = new List<Condition>();
             this.Fields = new List<string>();
-            this.Actions = new List<IActionApiModel>();
         }
 
         public AsaRefDataRule(RuleApiModel rule) : this()
@@ -152,7 +151,11 @@ namespace Microsoft.Azure.IoTSolutions.AsaManager.TelemetryRulesAgent.Models
                 this.conditions.Add(condition);
                 this.Fields.Add(c.Field);
             }
-            this.Actions = rule.Actions;
+
+            if (rule.Actions != null && rule.Actions.Count > 0)
+            {
+                this.Actions = rule.Actions;
+            }
         }
 
         private static string GetAggregationWindowValue(string calculation, long timePeriod)


### PR DESCRIPTION

# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
Ensure we don't serialize Actions as [], instead leave out actions if they are empty. This will allow asa and the telemetry service to run faster, as actions processor has to currently ignore empty actions.

# Motivation for the change
<!-- Please explain the motivation for making this change -->
Use less asa memory.