### PR TITLE
Lookup connectivity status of edge devices through module lookups

### DIFF
--- a/iothub-manager/Services.Test/DevicesTest.cs
+++ b/iothub-manager/Services.Test/DevicesTest.cs
@@ -113,6 +113,10 @@ namespace Services.Test
             var edgeDeviceFromTwin = "edgeDeviceFromTwin";
 
             this.registryMock
+                .Setup(x => x.CreateQuery(It.IsAny<string>()))
+                .Returns(new ResultQuery(0));
+
+            this.registryMock
                 .Setup(x => x.GetTwinAsync(nonEdgeDevice))
                 .ReturnsAsync(DevicesTest.CreateTestTwin(0));
             this.registryMock

--- a/iothub-manager/Services.Test/helpers/ResultQuery.cs
+++ b/iothub-manager/Services.Test/helpers/ResultQuery.cs
@@ -19,12 +19,11 @@ namespace Services.Test.helpers
         /// devices are created with deviceIds starting from deviceId{startIndex}
         /// </summary>
         /// <param name="numResults">Number of results to create</param>
-        /// <param name="startIndex">Index used for creating deviceId i.e. deviceId{startIndex}</param>
-        public ResultQuery(int numResults, int startIndex = 0)
+        public ResultQuery(int numResults)
         {
             this.results = new List<Twin>();
             this.deviceQueryResults = new List<string>();
-            for (int i = startIndex; i < numResults + startIndex; i++)
+            for (int i = 0; i < numResults; i++)
             {
                 this.results.Add(ResultQuery.CreateTestTwin(i));
                 this.deviceQueryResults.Add("{" + $"'{DEVICE_ID_KEY}':'device{i}'" + "}");

--- a/iothub-manager/Services.Test/helpers/ResultQuery.cs
+++ b/iothub-manager/Services.Test/helpers/ResultQuery.cs
@@ -14,11 +14,11 @@ namespace Services.Test.helpers
         private readonly List<Twin> results;
         private readonly List<string> deviceQueryResults;
 
-        public ResultQuery(int numResults)
+        public ResultQuery(int numResults, int startIndex = 0)
         {
             this.results = new List<Twin>();
             this.deviceQueryResults = new List<string>();
-            for (int i = 0; i < numResults; i++)
+            for (int i = startIndex; i < numResults + startIndex; i++)
             {
                 this.results.Add(ResultQuery.CreateTestTwin(i));
                 this.deviceQueryResults.Add("{" + $"'{DEVICE_ID_KEY}':'device{i}'" + "}");
@@ -91,7 +91,7 @@ namespace Services.Test.helpers
 
         private static Twin CreateTestTwin(int valueToReport)
         {
-            var twin = new Twin()
+            var twin = new Twin($"device{valueToReport}")
             {
                 Properties = new TwinProperties()
             };

--- a/iothub-manager/Services.Test/helpers/ResultQuery.cs
+++ b/iothub-manager/Services.Test/helpers/ResultQuery.cs
@@ -14,6 +14,12 @@ namespace Services.Test.helpers
         private readonly List<Twin> results;
         private readonly List<string> deviceQueryResults;
 
+        /// <summary>
+        /// Constructs a test set of twin query results. numResults number of
+        /// devices are created with deviceIds starting from deviceId{startIndex}
+        /// </summary>
+        /// <param name="numResults">Number of results to create</param>
+        /// <param name="startIndex">Index used for creating deviceId i.e. deviceId{startIndex}</param>
         public ResultQuery(int numResults, int startIndex = 0)
         {
             this.results = new List<Twin>();

--- a/iothub-manager/Services/Devices.cs
+++ b/iothub-manager/Services/Devices.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.Services
         private const int MAX_GET_LIST = 1000;
         private const string QUERY_PREFIX = "SELECT * FROM devices";
         private const string MODULE_QUERY_PREFIX = "SELECT * FROM devices.modules";
-        private string DEVICES_CONNECTED_QUERY = "connectionState = 'Connected'";
+        private const string DEVICES_CONNECTED_QUERY = "connectionState = 'Connected'";
 
         private RegistryManager registry;
         private string ioTHubHostName;

--- a/iothub-manager/Services/Devices.cs
+++ b/iothub-manager/Services/Devices.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.Services
         private const int MAX_GET_LIST = 1000;
         private const string QUERY_PREFIX = "SELECT * FROM devices";
         private const string MODULE_QUERY_PREFIX = "SELECT * FROM devices.modules";
-        private const string DEVICES_CONNECTED_QUERY = "connectionState = 'Connected'";
+        private string DEVICES_CONNECTED_QUERY = "connectionState = 'Connected'";
 
         private RegistryManager registry;
         private string ioTHubHostName;
@@ -314,7 +314,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.Services
         /// <returns>True if one of the modules for this device is connected.</returns>
         private async Task<bool> DoesDeviceHaveConnectedModules(string deviceId)
         {
-            var query = $"deviceId={deviceId} AND {DEVICES_CONNECTED_QUERY}";
+            var query = $"deviceId='{deviceId}' AND {DEVICES_CONNECTED_QUERY}";
             var edgeModules = await this.GetModuleTwinsByQueryAsync(query, "");
             return edgeModules.Items.Any();
         }


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
Makes a query to IoT Hub for list of modules that are reporting as connected. For these modules belonging to edge devices we interpret this as that edge device being connected.

# Motivation for the change
IoT Hub reports connection status based on status of the device link. In the case of edge the device link doesn't do much and most things happen in the modules. So we instead interpret it as up if any module is online. 
