### PR TITLE
Add "ApplicationPermissions" to /solution-settings/actions

### DIFF
--- a/config/Services.Test/AzureResourceManagerClientTest.cs
+++ b/config/Services.Test/AzureResourceManagerClientTest.cs
@@ -20,10 +20,6 @@ namespace Services.Test
         private const string MOCK_ARM_ENDPOINT_URL = @"https://management.azure.com";
         private const string MOCK_API_VERSION = @"2016-06-01";
 
-        private const string APP_PERMISSIONS_KEY = "ApplicationPermissions";
-        private const string CONTRIBUTOR_PERMISSIONS_KEY = "Contributor";
-        private const string OWNER_PERMISSIONS_KEY = "Owner";
-
         private readonly string logicAppTestConnectionUrl;
 
         private readonly Mock<IHttpClient> mockHttpClient;

--- a/config/Services.Test/AzureResourceManagerClientTest.cs
+++ b/config/Services.Test/AzureResourceManagerClientTest.cs
@@ -2,6 +2,7 @@
 
 using System.Net;
 using System.Threading.Tasks;
+using Microsoft.Azure.IoTSolutions.UIConfig.Services.Exceptions;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.External;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Http;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Runtime;
@@ -18,17 +19,22 @@ namespace Services.Test
         private const string MOCK_RESOURCE_GROUP = @"example-name";
         private const string MOCK_ARM_ENDPOINT_URL = @"https://management.azure.com";
         private const string MOCK_API_VERSION = @"2016-06-01";
+
+        private const string APP_PERMISSIONS_KEY = "ApplicationPermissions";
+        private const string CONTRIBUTOR_PERMISSIONS_KEY = "Contributor";
+        private const string OWNER_PERMISSIONS_KEY = "Owner";
+
         private readonly string logicAppTestConnectionUrl;
 
         private readonly Mock<IHttpClient> mockHttpClient;
-        private readonly Mock<IUserManagementClient> mockUserManagementClinet;
+        private readonly Mock<IUserManagementClient> mockUserManagementClient;
 
         private readonly AzureResourceManagerClient client;
 
         public AzureResourceManagerClientTest()
         {
             this.mockHttpClient = new Mock<IHttpClient>();
-            this.mockUserManagementClinet = new Mock<IUserManagementClient>();
+            this.mockUserManagementClient = new Mock<IUserManagementClient>();
             this.client = new AzureResourceManagerClient(
                 this.mockHttpClient.Object,
                 new ServicesConfig
@@ -38,10 +44,10 @@ namespace Services.Test
                     ArmEndpointUrl = MOCK_ARM_ENDPOINT_URL,
                     ManagementApiVersion = MOCK_API_VERSION
                 },
-                this.mockUserManagementClinet.Object);
+                this.mockUserManagementClient.Object);
 
             this.logicAppTestConnectionUrl = $"{MOCK_ARM_ENDPOINT_URL}" +
-                                        $"subscriptions/{MOCK_SUBSCRIPTION_ID}/" +
+                                        $"/subscriptions/{MOCK_SUBSCRIPTION_ID}/" +
                                         $"resourceGroups/{MOCK_RESOURCE_GROUP}/" +
                                         "providers/Microsoft.Web/connections/" +
                                         "office365-connector/extensions/proxy/testconnection?" +
@@ -98,6 +104,18 @@ namespace Services.Test
                     this.logicAppTestConnectionUrl))), Times.Once);
 
             Assert.False(result);
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public async Task GetOffice365IsEnabled_ThrowsIfNotAuthorizd()
+        {
+            // Arrange
+            this.mockUserManagementClient
+                .Setup(x => x.GetTokenAsync())
+                .ThrowsAsync(new NotAuthorizedException());
+
+            // Act & Assert
+            await Assert.ThrowsAsync<NotAuthorizedException>(async () => await this.client.IsOffice365EnabledAsync());
         }
     }
 }

--- a/config/Services/Exceptions/NotAuthorizedException.cs
+++ b/config/Services/Exceptions/NotAuthorizedException.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+
+namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.Exceptions
+{
+    /// <summary>
+    /// This exception is thrown when the user or the application
+    /// is not authorized to perform the action.
+    /// </summary>
+    public class NotAuthorizedException : Exception
+    {
+        public NotAuthorizedException() : base()
+        {
+        }
+
+        public NotAuthorizedException(string message) : base(message)
+        {
+        }
+
+        public NotAuthorizedException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/config/Services/External/AzureResourceManagerClient.cs
+++ b/config/Services/External/AzureResourceManagerClient.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Exceptions;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Http;
@@ -41,7 +42,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.External
             }
 
             var logicAppTestConnectionUri = this.config.ArmEndpointUrl +
-                                               $"subscriptions/{this.config.SubscriptionId}/" +
+                                               $"/subscriptions/{this.config.SubscriptionId}/" +
                                                $"resourceGroups/{this.config.ResourceGroup}/" +
                                                "providers/Microsoft.Web/connections/" +
                                                "office365-connector/extensions/proxy/testconnection?" +
@@ -50,6 +51,13 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.External
             var request = await this.CreateRequest(logicAppTestConnectionUri);
 
             var response = await this.httpClient.GetAsync(request);
+
+            if (response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                throw new NotAuthorizedException("The application is not authorized and has not been " +
+                                                 "assigned owner permissions for the subscription. Go to the Azure portal and " +
+                                                 "assign the application as an owner in order to retrieve the token.");
+            }
 
             return response.IsSuccessStatusCode;
         }

--- a/config/Services/External/AzureResourceManagerClient.cs
+++ b/config/Services/External/AzureResourceManagerClient.cs
@@ -55,8 +55,8 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.External
             if (response.StatusCode == HttpStatusCode.Forbidden)
             {
                 throw new NotAuthorizedException("The application is not authorized and has not been " +
-                                                 "assigned owner permissions for the subscription. Go to the Azure portal and " +
-                                                 "assign the application as an owner in order to retrieve the token.");
+                                                 "assigned contributor permissions for the subscription. Go to the Azure portal and " +
+                                                 "assign the application as a contributor in order to retrieve the token.");
             }
 
             return response.IsSuccessStatusCode;

--- a/config/Services/External/UserManagementClient.cs
+++ b/config/Services/External/UserManagementClient.cs
@@ -91,8 +91,13 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.External
             {
                 case HttpStatusCode.NotFound:
                     throw new ResourceNotFoundException($"{response.Content}, request URL = {request.Uri}");
+                case HttpStatusCode.Forbidden:
+                    throw new NotAuthorizedException("The user or the application is not authorized to make the " +
+                                                     $"request to the user management service, content = {response.Content}, " +
+                                                     $"request URL = {request.Uri}");
                 default:
-                    throw new HttpRequestException($"Http request failed, status code = {response.StatusCode}, content = {response.Content}, request URL = {request.Uri}");
+                    throw new HttpRequestException($"Http request failed, status code = {response.StatusCode}, " +
+                                                   "content = {response.Content}, request URL = {request.Uri}");
             }
         }
     }

--- a/config/Services/Models/Actions/EmailActionSettings.cs
+++ b/config/Services/Models/Actions/EmailActionSettings.cs
@@ -14,9 +14,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.Models.Actions
     {
         private const string IS_ENABLED_KEY = "IsEnabled";
         private const string OFFICE365_CONNECTOR_URL_KEY = "Office365ConnectorUrl";
-        private const string APP_PERMISSIONS_KEY = "ApplicationPermissions";
-        private const string CONTRIBUTOR_PERMISSIONS_KEY = "Contributor";
-        private const string OWNER_PERMISSIONS_KEY = "Owner";
+        private const string APP_PERMISSIONS_KEY = "ApplicationPermissionsAssigned";
 
         private readonly IAzureResourceManagerClient resourceManagerClient;
         private readonly IServicesConfig servicesConfig;
@@ -45,7 +43,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.Models.Actions
         {
             // Check signin status of Office 365 Logic App Connector
             var office365IsEnabled = false;
-            var applicationPermissions = OWNER_PERMISSIONS_KEY;
+            var applicationPermissionsAssigned = true;
             try
             {
                 office365IsEnabled = await this.resourceManagerClient.IsOffice365EnabledAsync();
@@ -55,13 +53,13 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.Models.Actions
                 // If there is a 403 Not Authorized exception, it means the application has not
                 // been given owner permissions to make the isEnabled check. This can be configured
                 // by an owner in the Azure Portal.
-                applicationPermissions = CONTRIBUTOR_PERMISSIONS_KEY;
+                applicationPermissionsAssigned = false;
                 this.log.Debug("The application is not authorized and has not been " +
                                "assigned owner permissions for the subscription. Go to the Azure portal and " +
                                "assign the application as an owner in order to retrieve the token.", () => new { notAuthorizedException });
             }
             this.Settings.Add(IS_ENABLED_KEY, office365IsEnabled);
-            this.Settings.Add(APP_PERMISSIONS_KEY, applicationPermissions);
+            this.Settings.Add(APP_PERMISSIONS_KEY, applicationPermissionsAssigned);
 
             // Get Url for Office 365 Logic App Connector setup in portal
             // for display on the webui for one-time setup.

--- a/config/WebService/v1/Filters/ExceptionsFilterAttribute.cs
+++ b/config/WebService/v1/Filters/ExceptionsFilterAttribute.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Exceptions;
-using Microsoft.Azure.IoTSolutions.UIConfig.WebService.Auth;
 using Microsoft.Azure.IoTSolutions.UIConfig.WebService.v1.Exceptions;
 using Newtonsoft.Json;
 
@@ -52,7 +51,8 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.v1.Filters
             {
                 context.Result = this.GetResponse(HttpStatusCode.InternalServerError, context.Exception);
             }
-            else if (context.Exception is NotAuthorizedException)
+            else if (context.Exception is Auth.NotAuthorizedException ||
+                     context.Exception is Services.Exceptions.NotAuthorizedException)
             {
                 context.Result = this.GetResponse(HttpStatusCode.Forbidden, context.Exception);
             }

--- a/config/docs/API_SPEC_ACTION_SETTINGS.md
+++ b/config/docs/API_SPEC_ACTION_SETTINGS.md
@@ -28,7 +28,7 @@ Content-Type: application/json
             "Type": "Email",
             "Settings": {
                 "IsEnabled": false,
-                "ApplicationPermissionsAssigned": false
+                "ApplicationPermissionsAssigned": false,
                 "Office365ConnectorUrl": "https://portal.azure.com/#@{tenant}/resource/subscriptions/{subscription}/resourceGroups/{resource-group}/providers/Microsoft.Web/connections/office365-connector/edit"
             }
         }

--- a/config/docs/API_SPEC_ACTION_SETTINGS.md
+++ b/config/docs/API_SPEC_ACTION_SETTINGS.md
@@ -5,10 +5,11 @@ API Specification - Action Settings
 
 The list of configuration settings for all action types.
 
-The ApplicationPermissions attribute indicates whether or not the application has
-been given "Owner" permissions in order to make management API calls. If the application
-does not have "Owner" permissions, then users will need to check on resources manually from
-the Azure portal.
+The ApplicationPermissionsAssigned attribute indicates whether or not the application has
+been given "Contributor" permissions in order to make management API calls. If the application
+does not have "Contributor" permissions, then users will need to check on resources manually from
+the Azure portal. This can happen when the user deploying the application does not have "Owner"
+permissions in order to assign the application the necessry permissions.
 
 Request:
 ```
@@ -27,7 +28,7 @@ Content-Type: application/json
             "Type": "Email",
             "Settings": {
                 "IsEnabled": false,
-                "ApplicationPermissions" ["Owner" | "Contributor"]
+                "ApplicationPermissionsAssigned": false
                 "Office365ConnectorUrl": "https://portal.azure.com/#@{tenant}/resource/subscriptions/{subscription}/resourceGroups/{resource-group}/providers/Microsoft.Web/connections/office365-connector/edit"
             }
         }

--- a/config/docs/API_SPEC_ACTION_SETTINGS.md
+++ b/config/docs/API_SPEC_ACTION_SETTINGS.md
@@ -5,6 +5,11 @@ API Specification - Action Settings
 
 The list of configuration settings for all action types.
 
+The ApplicationPermissions attribute indicates whether or not the application has
+been given "Owner" permissions in order to make management API calls. If the application
+does not have "Owner" permissions, then users will need to check on resources manually from
+the Azure portal.
+
 Request:
 ```
 GET /v1/solution-settings/actions
@@ -22,6 +27,7 @@ Content-Type: application/json
             "Type": "Email",
             "Settings": {
                 "IsEnabled": false,
+                "ApplicationPermissions" ["Owner" | "Contributor"]
                 "Office365ConnectorUrl": "https://portal.azure.com/#@{tenant}/resource/subscriptions/{subscription}/resourceGroups/{resource-group}/providers/Microsoft.Web/connections/office365-connector/edit"
             }
         }


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
<!-- Please provide enough information so others can review your pull request -->
If the solution was deployed by a "Contributor" on the subscription, that individual does not have permissions to assign the application as a "Contributor" in order to make calls to the management.azure.com apis. This is needed in order to call the "testconnection" api for the Logic App connector. 

In order to get this information to the webui meaningfully, the actions settings now will additionally return the "ApplicationPermissionsAssigned" to let the user know what the next best course of action would be to ensure email actions are set up correctly.

```json
{  
  "Items":[  
    {  
      "Type":"Email",
      "Settings":{  
        "IsEnabled": false,
        "ApplicationPermissionsAssigned": false,
        "Office365ConnectorUrl":"https://portal.azure.com/#@1234-567-89/resource/subscriptions/1234/resourceGroups/example-rg-name/providers/Microsoft.Web/connections/office365-connector/edit"
      }
    }
  ],
  "$metadata":{  
    "$type":"ActionSettingsList;1",
    "$url":"/v1/solution-settings/actions"
  }
}
```
