### PR TITLE
Restrict public get methods to admin/readonly users

### DIFF
--- a/config/WebService/v1/Controllers/DeviceGroupController.cs
+++ b/config/WebService/v1/Controllers/DeviceGroupController.cs
@@ -19,12 +19,14 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.v1.Controllers
         }
 
         [HttpGet]
+        [Authorize("ReadAll")]
         public async Task<DeviceGroupListApiModel> GetAllAsync()
         {
             return new DeviceGroupListApiModel(await this.storage.GetAllDeviceGroupsAsync());
         }
 
         [HttpGet("{id}")]
+        [Authorize("ReadAll")]
         public async Task<DeviceGroupApiModel> GetAsync(string id)
         {
             return new DeviceGroupApiModel(await this.storage.GetDeviceGroupAsync(id));

--- a/config/WebService/v1/Controllers/PackageController.cs
+++ b/config/WebService/v1/Controllers/PackageController.cs
@@ -24,12 +24,14 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.v1.Controllers
         }
 
         [HttpGet]
+        [Authorize("ReadAll")]
         public async Task<PackageListApiModel> GetAllAsync()
         {
             return new PackageListApiModel(await this.storage.GetPackagesAsync());
         }
 
         [HttpGet("{id}")]
+        [Authorize("ReadAll")]
         public async Task<PackageApiModel> GetAsync(string id)
         {
             if (string.IsNullOrEmpty(id))

--- a/config/WebService/v1/Controllers/SeedController.cs
+++ b/config/WebService/v1/Controllers/SeedController.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.v1.Controllers
         }
 
         [HttpPost]
+        [Authorize("ReadAll")]
         public async Task PostAsync()
         {
             await this.seed.TrySeedAsync();

--- a/config/WebService/v1/Controllers/SolutionSettings.cs
+++ b/config/WebService/v1/Controllers/SolutionSettings.cs
@@ -23,18 +23,21 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.v1.Controllers
         }
 
         [HttpGet("solution-settings/theme")]
+        [Authorize("ReadAll")]
         public async Task<object> GetThemeAsync()
         {
             return await this.storage.GetThemeAsync();
         }
 
         [HttpPut("solution-settings/theme")]
+        [Authorize("ReadAll")]
         public async Task<object> SetThemeAsync([FromBody] object theme)
         {
             return await this.storage.SetThemeAsync(theme);
         }
 
         [HttpGet("solution-settings/logo")]
+        [Authorize("ReadAll")]
         public async Task GetLogoAsync()
         {
             var model = await this.storage.GetLogoAsync();
@@ -42,6 +45,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.v1.Controllers
         }
 
         [HttpPut("solution-settings/logo")]
+        [Authorize("ReadAll")]
         public async Task SetLogoAsync()
         {
             MemoryStream memoryStream = new MemoryStream();

--- a/config/WebService/v1/Controllers/StatusController.cs
+++ b/config/WebService/v1/Controllers/StatusController.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.v1.Controllers
             this.log = logger;
         }
 
+        [Authorize("ReadAll")]
         public StatusApiModel Get()
         {
             // TODO: calculate the actual service status

--- a/config/WebService/v1/Controllers/UserSettings.cs
+++ b/config/WebService/v1/Controllers/UserSettings.cs
@@ -18,12 +18,14 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.v1.Controllers
         }
 
         [HttpGet("user-settings/{id}")]
+        [Authorize("ReadAll")]
         public async Task<object> GetUserSettingAsync(string id)
         {
             return await this.storage.GetUserSetting(id);
         }
 
         [HttpPut("user-settings/{id}")]
+        [Authorize("ReadAll")]
         public async Task<object> SetUserSettingAsync(string id, [FromBody] object setting)
         {
             return await this.storage.SetUserSetting(id, setting);

--- a/device-telemetry/WebService/v1/Controllers/AlarmsByRuleController.cs
+++ b/device-telemetry/WebService/v1/Controllers/AlarmsByRuleController.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
         }
 
         [HttpGet]
+        [Authorize("ReadAll")]
         public async Task<AlarmByRuleListApiModel> GetAsync(
             [FromQuery] string from,
             [FromQuery] string to,
@@ -52,6 +53,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
         }
 
         [HttpPost]
+        [Authorize("ReadAll")]
         public async Task<AlarmByRuleListApiModel> PostAsync([FromBody] QueryApiModel body)
         {
             string[] deviceIds = body.Devices == null
@@ -68,6 +70,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
         }
 
         [HttpGet("{id}")]
+        [Authorize("ReadAll")]
         public AlarmListByRuleApiModel Get(
             [FromRoute] string id,
             [FromQuery] string from,
@@ -87,6 +90,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
         }
 
         [HttpPost("{id}")]
+        [Authorize("ReadAll")]
         public AlarmListByRuleApiModel Post(
             [FromRoute] string id,
             [FromBody] QueryApiModel body)

--- a/device-telemetry/WebService/v1/Controllers/AlarmsController.cs
+++ b/device-telemetry/WebService/v1/Controllers/AlarmsController.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
         }
 
         [HttpGet(Version.PATH + "/[controller]")]
+        [Authorize("ReadAll")]
         public AlarmListApiModel List(
             [FromQuery] string from,
             [FromQuery] string to,
@@ -52,6 +53,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
         }
 
         [HttpPost(Version.PATH + "/[controller]")]
+        [Authorize("ReadAll")]
         public AlarmListApiModel Post([FromBody] QueryApiModel body)
         {
             string[] deviceIds = body.Devices == null
@@ -68,6 +70,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
         }
 
         [HttpGet(Version.PATH + "/[controller]/{id}")]
+        [Authorize("ReadAll")]
         public AlarmApiModel Get([FromRoute] string id)
         {
             Alarm alarm = this.alarmService.Get(id);

--- a/device-telemetry/WebService/v1/Controllers/MessagesController.cs
+++ b/device-telemetry/WebService/v1/Controllers/MessagesController.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
         }
 
         [HttpGet]
+        [Authorize("ReadAll")]
         public async Task<MessageListApiModel> GetAsync(
             [FromQuery] string from,
             [FromQuery] string to,
@@ -48,6 +49,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
         }
 
         [HttpPost]
+        [Authorize("ReadAll")]
         public async Task<MessageListApiModel> PostAsync([FromBody] QueryApiModel body)
         {
             string[] deviceIds = body.Devices == null

--- a/device-telemetry/WebService/v1/Controllers/RulesController.cs
+++ b/device-telemetry/WebService/v1/Controllers/RulesController.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
         }
 
         [HttpGet("{id}")]
+        [Authorize("ReadAll")]
         public async Task<RuleApiModel> GetAsync([FromRoute] string id)
         {
             Rule rule = await this.ruleService.GetAsync(id);
@@ -28,6 +29,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
         }
 
         [HttpGet]
+        [Authorize("ReadAll")]
         public async Task<RuleListApiModel> ListAsync(
             [FromQuery] string order,
             [FromQuery] int? skip,

--- a/device-telemetry/WebService/v1/Controllers/StatusController.cs
+++ b/device-telemetry/WebService/v1/Controllers/StatusController.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
         }
 
         [HttpGet]
+        [Authorize("ReadAll")]
         public async Task<StatusApiModel> Get()
         {
             var statusIsOk = true;

--- a/iothub-manager/WebService/v1/Controllers/DeploymentsController.cs
+++ b/iothub-manager/WebService/v1/Controllers/DeploymentsController.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Controllers
         }
 
         [HttpGet]
+        [Authorize("ReadAll")]
         public async Task<DeploymentListApiModel> GetAsync()
         {
             return new DeploymentListApiModel(await this.deployments.ListAsync());

--- a/iothub-manager/WebService/v1/Controllers/DevicePropertiesController.cs
+++ b/iothub-manager/WebService/v1/Controllers/DevicePropertiesController.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Controllers
         }
 
         [HttpGet]
+        [Authorize("ReadAll")]
         public async Task<DevicePropertiesApiModel> GetAsync()
         {
             return new DevicePropertiesApiModel(await this.deviceProperties.GetListAsync());

--- a/iothub-manager/WebService/v1/Controllers/DevicesController.cs
+++ b/iothub-manager/WebService/v1/Controllers/DevicesController.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Controllers
         /// <summary>Get a list of devices</summary>
         /// <returns>List of devices</returns>
         [HttpGet]
+        [Authorize("ReadAll")]
         public async Task<DeviceListApiModel> GetDevicesAsync([FromQuery] string query)
         {
             string continuationToken = string.Empty;
@@ -40,6 +41,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Controllers
         }
 
         [HttpPost("query")]
+        [Authorize("ReadAll")]
         public async Task<DeviceListApiModel> QueryDevicesAsync([FromBody] string query)
         {
             string continuationToken = string.Empty;
@@ -55,6 +57,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Controllers
         /// <param name="id">Device Id</param>
         /// <returns>Device information</returns>
         [HttpGet("{id}")]
+        [Authorize("ReadAll")]
         public async Task<DeviceRegistryApiModel> GetDeviceAsync(string id)
         {
             return new DeviceRegistryApiModel(await this.devices.GetAsync(id));

--- a/iothub-manager/WebService/v1/Controllers/JobsController.cs
+++ b/iothub-manager/WebService/v1/Controllers/JobsController.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Controllers
         /// <param name="to">Optional. The end time of interesting period</param>
         /// <returns>The list of jobs</returns>
         [HttpGet]
+        [Authorize("ReadAll")]
         public async Task<IEnumerable<JobApiModel>> GetAsync(
             [FromQuery] JobType? jobType,
             [FromQuery] JobStatus? jobStatus,
@@ -51,6 +52,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Controllers
         /// <param name="deviceJobStatus">The interesting device job status. `null` means no restrict</param>
         /// <returns>The job object</returns>
         [HttpGet("{jobId}")]
+        [Authorize("ReadAll")]
         public async Task<JobApiModel> GetJobAsync(
             string jobId,
             [FromQuery]bool? includeDeviceDetails,

--- a/iothub-manager/WebService/v1/Controllers/ModulesController.cs
+++ b/iothub-manager/WebService/v1/Controllers/ModulesController.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Controllers
         /// <param name="query">Where clause of IoTHub query</param>
         /// <returns>List of module twins</returns>
         [HttpGet]
+        [Authorize("ReadAll")]
         public async Task<TwinPropertiesListApiModel> GetModuleTwinsAsync([FromQuery] string query)
         {
             string continuationToken = string.Empty;
@@ -41,6 +42,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Controllers
         /// <param name="query">Where clause of IoTHub query</param>
         /// <returns>List of module twins</returns>
         [HttpPost("query")]
+        [Authorize("ReadAll")]
         public async Task<TwinPropertiesListApiModel> QueryModuleTwinsAsync([FromBody] string query)
         {
             return await this.GetModuleTwinsAsync(query);
@@ -51,6 +53,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Controllers
         /// <param name="moduleId">Module Id</param>
         /// <returns>Device information</returns>
         [HttpGet("{deviceId}/{moduleId}")]
+        [Authorize("ReadAll")]
         public async Task<TwinPropertiesApiModel> GetModuleTwinAsync(string deviceId, string moduleId)
         {
             if (string.IsNullOrWhiteSpace(deviceId))

--- a/iothub-manager/WebService/v1/Controllers/StatusController.cs
+++ b/iothub-manager/WebService/v1/Controllers/StatusController.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.v1.Controllers
         /// <summary>Return the service status</summary>
         /// <returns>Status object</returns>
         [HttpGet]
+        [Authorize("ReadAll")]
         public StatusApiModel Get()
         {
             return new StatusApiModel(true, "Alive and well");


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
Add Authorize tags to all methods in public services that were previously not tagged, with the ReadAll permission. Both admin and readonly users have this permission. This will restrict access to users with roles, instead of any user.

# Motivation for the change
Update RBAC changes
