### PR TITLE
Fix retry logic for deployment not seeding correctly

### DIFF
--- a/config/Services/Seed.cs
+++ b/config/Services/Seed.cs
@@ -74,12 +74,17 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services
             }
 
             this.log.Info("Seed begin", () => { });
-            await this.SeedAsync();
-            this.log.Info("Seed end", () => { });
-
-            await this.SetCompletedFlagAsync();
-
-            await this.mutex.LeaveAsync(SEED_COLLECTION_ID, MUTEX_KEY);
+            try
+            {
+                await this.SeedAsync();
+                this.log.Info("Seed end", () => { });
+                await this.SetCompletedFlagAsync();
+                this.log.Info("Seed completed flag set", () => { });
+            }
+            finally
+            {
+                await this.mutex.LeaveAsync(SEED_COLLECTION_ID, MUTEX_KEY);
+            }
         }
 
         private async Task<bool> CheckCompletedFlagAsync()


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
The seed retry when failed was not releasing the mutex. Because of this the 2nd attempt would see a conflict, and exit gracefully. Now we make sure the mutex is released in a finally block so that the second attempt goes through.

I verified a standard deployment with this change where I saw the first seed fail. And the second one succeed.