### PR TITLE
Fix key not found exception when viewing device groups

### DIFF
--- a/iothub-manager/Services.Test/DevicesTest.cs
+++ b/iothub-manager/Services.Test/DevicesTest.cs
@@ -243,7 +243,7 @@ namespace Services.Test
         }
 
         /// <summary>
-        /// Returns a set of 4 devices the first two being non-edge
+        /// Returns a set of edge and non-edge devices
         /// </summary>
         /// <returns></returns>
         private IEnumerable<Device> CreateTestListOfDevices()
@@ -254,6 +254,8 @@ namespace Services.Test
                 DevicesTest.CreateTestDevice("device1", false),
                 DevicesTest.CreateTestDevice("device2", true),
                 DevicesTest.CreateTestDevice("device3", true),
+                DevicesTest.CreateTestDevice("device4", false),
+                DevicesTest.CreateTestDevice("device5", true),
             };
         }
     }


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
When checking if an edge device is connected or not we look up the status of the device in the device twin map. However, when we are only viewing a subset of devices (using a group query), the twin map may not have all the devices that were returned in the getDevicesAsync call. This leads to a key not found exception.

The fix is to filter our devices list to only be the devices that were returned in the query (all the devices that are in the twin map).

# Motivation for the change
Viewing list of devices in groups is broken.  This fixes this for both devices page and deployments page.
