### PR TITLE
Rerun seeding in the cases where it times out

### DIFF
--- a/config/WebService/RecurringTasks.cs
+++ b/config/WebService/RecurringTasks.cs
@@ -46,9 +46,15 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService
                 try
                 {
                     this.log.Info("Creating seed data...", () => { });
-                    this.seed.TrySeedAsync().Wait(SEED_TIMEOUT_SECS * 1000);
-                    this.log.Info("Seed data created", () => { });
-                    return;
+                    var taskCompleted = this.seed.TrySeedAsync().Wait(SEED_TIMEOUT_SECS * 1000);
+
+                    if (taskCompleted)
+                    {
+                        this.log.Info("Seed data created", () => { });
+                        return;
+                    }
+
+                    this.log.Warn("Seed creation timed out. Setting to rerun.", () => { });
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
When tasks timeout when trying to seed due to some service taking long to start or another intermittent issue the wait operation doesn't throw an exception. It returns false, and in the old code would simply return meaning we never actually run again.

In the new case if the task didn't completely we throw a warning and allow it to run again.

# Motivation for the change
Fix deployments that are taking a long time to seed properly.
