### PR TITLE
Update ETag validation and allow wildcards

### DIFF
--- a/device-telemetry/Services.Test/RulesTest.cs
+++ b/device-telemetry/Services.Test/RulesTest.cs
@@ -515,7 +515,7 @@ namespace Services.Test
                 {
                     Name = "Sample 1",
                     Enabled = true,
-                    Description = "Sample description 1",
+                    Description = "Sample description 1 -- Pressure >= 298",
                     GroupId = "Prototyping devices",
                     Severity = SeverityType.Critical,
                     Conditions = sampleConditions,

--- a/device-telemetry/Services.Test/RulesTest.cs
+++ b/device-telemetry/Services.Test/RulesTest.cs
@@ -457,6 +457,21 @@ namespace Services.Test
             await Assert.ThrowsAsync<InvalidInputException>(async () => await this.rules.UpsertIfNotDeletedAsync(rule));
         }
 
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void InputValidationPassesWithValidRule()
+        {
+            // Arrange
+            this.ThereAreSomeRulesInStorage();
+
+            List<Rule> rulesList = this.GetSampleRulesList();
+
+            // Act & Assert
+            foreach (var rule in rulesList)
+            {
+                rule.Validate();
+            }
+        }
+
         private void ThereAreNoRulessInStorage()
         {
             this.rulesMock.Setup(x => x.GetListAsync(null, 0, LIMIT, null, false))
@@ -464,6 +479,14 @@ namespace Services.Test
         }
 
         private void ThereAreSomeRulesInStorage()
+        {
+            var sampleRules = this.GetSampleRulesList();
+
+            this.rulesMock.Setup(x => x.GetListAsync(null, 0, LIMIT, null, false))
+                .ReturnsAsync(sampleRules);
+        }
+
+        private List<Rule> GetSampleRulesList()
         {
             var sampleConditions = new List<Condition>
             {
@@ -507,11 +530,22 @@ namespace Services.Test
                     Severity =  SeverityType.Warning,
                     Conditions = sampleConditions,
                     Actions = sampleActions
+                },
+                new Rule()
+                {
+                    ETag = "*",
+                    Name = "Sample 3",
+                    Enabled = true,
+                    Calculation = CalculationType.Instant,
+                    Description = "Sample description 2.",
+                    GroupId =  "Chillers",
+                    Severity =  SeverityType.Warning,
+                    Conditions = sampleConditions,
+                    Actions = sampleActions
                 }
             };
 
-            this.rulesMock.Setup(x => x.GetListAsync(null, 0, LIMIT, null, false))
-                .ReturnsAsync(sampleRules);
+            return sampleRules;
         }
 
         /**

--- a/device-telemetry/Services/Helpers/InputValidator.cs
+++ b/device-telemetry/Services/Helpers/InputValidator.cs
@@ -5,14 +5,12 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Helpers
 {
     public class InputValidator
     {
-        private const string INVALID_CHARACTER = @"[^A-Za-z0-9:;.,_\-*]";
+        private const string INVALID_CHARACTER = @"[^A-Za-z0-9:;.!,_\-* ]";
 
         // Check illegal characters in input
         public static void Validate(string input)
         {
-            input = input.Trim();
-
-            if (Regex.IsMatch(input, INVALID_CHARACTER))
+            if (Regex.IsMatch(input.Trim(), INVALID_CHARACTER))
             {
                 throw new InvalidInputException($"Input '{input}' contains invalid characters.");
             }

--- a/device-telemetry/Services/Helpers/InputValidator.cs
+++ b/device-telemetry/Services/Helpers/InputValidator.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Helpers
 {
     public class InputValidator
     {
-        private const string INVALID_CHARACTER = @"[^A-Za-z0-9:;.,_\-]";
+        private const string INVALID_CHARACTER = @"[^A-Za-z0-9:;.,_\-*]";
 
         // Check illegal characters in input
         public static void Validate(string input)

--- a/device-telemetry/Services/Models/Rule.cs
+++ b/device-telemetry/Services/Models/Rule.cs
@@ -46,7 +46,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Models
 
         public void Validate()
         {
-            InputValidator.Validate(this.ETag);
             InputValidator.Validate(this.Id);
             InputValidator.Validate(this.Name);
             InputValidator.Validate(this.Description);

--- a/device-telemetry/Services/Models/Rule.cs
+++ b/device-telemetry/Services/Models/Rule.cs
@@ -47,9 +47,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Models
         public void Validate()
         {
             InputValidator.Validate(this.Id);
-            InputValidator.Validate(this.Name);
-            InputValidator.Validate(this.Description);
-            InputValidator.Validate(this.GroupId);
         }
     }
 


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
<!-- Please provide enough information so others can review your pull request -->
Etags can contain characters like '*', so the strings are currently being flagged by the validation method. This change removes the check for ETags.

