### PR TITLE
Upgrade to DS-1.0.3 for local deployments

### DIFF
--- a/scripts/local/docker-compose.yml
+++ b/scripts/local/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - PCS_APPLICATION_SECRET
 
   devicesimulation:
-    image: azureiotpcs/device-simulation-dotnet:DS-1.0.2
+    image: azureiotpcs/device-simulation-dotnet:DS-1.0.3
     depends_on:
       - storageadapter
     environment:


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
<!-- Please provide enough information so others can review your pull request -->
Related to https://github.com/Azure/pcs-cli/pull/454, this change upgrades to DS-1.0.3 for local deployments.

This PR goes alongside Azure/device-simulation-dotnet#337 to update Remote Monitoring to Device Simulation release DS-1.0.3. This change includes User Agent tagging on top of the stable version DS-1.0.2.