### PR TITLE
Bug fix for device simulation local docker deployment

### DIFF
--- a/device-simulation/scripts/docker/run.cmd
+++ b/device-simulation/scripts/docker/run.cmd
@@ -24,6 +24,7 @@ docker run --detach -p 9003:9003 ^
     -e PCS_KEYVAULT_NAME ^
     -e PCS_AAD_APPID ^
     -e PCS_AAD_APPSECRET ^
+    -e PCS_STORAGEADAPTER_WEBSERVICE_URL=http://service.docker.internal:9022/v1 ^
     %DOCKER_IMAGE%:DS-1.0.5
 
 :: - - - - - - - - - - - - - -


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [ ] All new and existing tests passed.
- [ ] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
<!-- Please provide enough information so others can review your pull request -->
...

# Motivation for the change
<!-- Please explain the motivation for making this change -->
While deploying the RM locally, device-simulation is started as a docker container. The docker container should be able to talk to storage adapter running natively on the docker host.  Currently, the value for PCS_STORAGE_ADAPTER_URL is fetched from the KeyVault, where it is set to http://localhost:9022. This value cannot be utilized inside the container. This change will set the PCS_STORAGE_ADAPTER_URL  as an environment variable inside the container.