### PR TITLE
Add Time-To-Live for Token Validation in Auth Middleware

### DIFF
--- a/asa-manager/Services/Services.csproj
+++ b/asa-manager/Services/Services.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.10.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="2.0.1" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.5.0"  />
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="2.0.6" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
   </ItemGroup>
 </Project>

--- a/asa-manager/WebService/Auth/AuthMiddleware.cs
+++ b/asa-manager/WebService/Auth/AuthMiddleware.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Azure.IoTSolutions.AsaManager.WebService.Auth
         private TokenValidationParameters tokenValidationParams;
         private readonly bool authRequired;
         private bool tokenValidationInitialized;
+        private DateTime tokenValidationExpiration;
 
         public AuthMiddleware(
             // ReSharper disable once UnusedParameter.Local
@@ -67,6 +68,7 @@ namespace Microsoft.Azure.IoTSolutions.AsaManager.WebService.Auth
             this.log = log;
             this.authRequired = config.AuthRequired;
             this.tokenValidationInitialized = false;
+            this.tokenValidationExpiration = DateTime.UtcNow;
 
             // This will show in development mode, or in case auth is turned off
             if (!this.authRequired)
@@ -83,7 +85,8 @@ namespace Microsoft.Azure.IoTSolutions.AsaManager.WebService.Auth
                     this.config.JwtIssuer,
                     this.config.JwtAudience,
                     this.config.JwtAllowedAlgos,
-                    this.config.JwtClockSkew
+                    this.config.JwtClockSkew,
+                    this.config.OpenIdTimeToLive
                 });
 
                 this.InitializeTokenValidationAsync(CancellationToken.None).Wait();
@@ -196,7 +199,8 @@ namespace Microsoft.Azure.IoTSolutions.AsaManager.WebService.Auth
 
         private async Task<bool> InitializeTokenValidationAsync(CancellationToken token)
         {
-            if (this.tokenValidationInitialized) return true;
+            // If the token has been initialized and is not past expiry, return.
+            if (this.tokenValidationInitialized && !this.TokenValidationExpired()) return true;
 
             try
             {
@@ -224,6 +228,7 @@ namespace Microsoft.Azure.IoTSolutions.AsaManager.WebService.Auth
                 };
 
                 this.tokenValidationInitialized = true;
+                this.tokenValidationExpiration = DateTime.UtcNow.Add(this.config.OpenIdTimeToLive);
             }
             catch (Exception e)
             {
@@ -231,6 +236,15 @@ namespace Microsoft.Azure.IoTSolutions.AsaManager.WebService.Auth
             }
 
             return this.tokenValidationInitialized;
+        }
+
+        /// <summary>
+        /// Checks if the OpenId Connect token has hit the expiration time.
+        /// </summary>
+        /// <returns>true if the token has expired</returns>
+        private bool TokenValidationExpired()
+        {
+            return this.tokenValidationExpiration > DateTime.UtcNow;
         }
     }
 }

--- a/asa-manager/WebService/Auth/ClientAuthConfig.cs
+++ b/asa-manager/WebService/Auth/ClientAuthConfig.cs
@@ -36,6 +36,12 @@ namespace Microsoft.Azure.IoTSolutions.AsaManager.WebService.Auth
         // Clock skew allowed when validating tokens expiration
         // Default: 2 minutes
         TimeSpan JwtClockSkew { get; set; }
+
+        // Time to live for the OpenId Connect validation token.
+        // The metadata settings will expire so the token needs to be
+        // periodically recreated.
+        // Default: 7 days
+        TimeSpan OpenIdTimeToLive { get; set; }
     }
 
     public class ClientAuthConfig : IClientAuthConfig
@@ -49,5 +55,6 @@ namespace Microsoft.Azure.IoTSolutions.AsaManager.WebService.Auth
         public string JwtIssuer { get; set; }
         public string JwtAudience { get; set; }
         public TimeSpan JwtClockSkew { get; set; }
+        public TimeSpan OpenIdTimeToLive { get; set; }
     }
 }

--- a/asa-manager/WebService/Runtime/Config.cs
+++ b/asa-manager/WebService/Runtime/Config.cs
@@ -54,6 +54,9 @@ namespace Microsoft.Azure.IoTSolutions.AsaManager.WebService.Runtime
         private const string JWT_AUDIENCE_KEY = JWT_KEY + "aadAppId";
         private const string JWT_CLOCK_SKEW_KEY = JWT_KEY + "clockSkewSeconds";
 
+        private const string OPEN_ID_KEY = APPLICATION_KEY + "ClientAuth:OpenIdConnect:";
+        private const string OPEN_ID_TTL_KEY = OPEN_ID_KEY + "timeToLiveDays";
+
         private const string EVENTHUB_KEY = APPLICATION_KEY + "EventHub:";
         private const string EVENTHUB_CONNECTION_KEY = EVENTHUB_KEY + "messagesEventHubConnectionString";
         private const string EVENTHUB_NAME = EVENTHUB_KEY + "messagesEventHubName";
@@ -161,6 +164,8 @@ namespace Microsoft.Azure.IoTSolutions.AsaManager.WebService.Runtime
                 JwtAudience = configData.GetString(JWT_AUDIENCE_KEY, String.Empty),
                 // By default the allowed clock skew is 2 minutes
                 JwtClockSkew = TimeSpan.FromSeconds(configData.GetInt(JWT_CLOCK_SKEW_KEY, 120)),
+                // By default the time to live for the OpenId connect token is 7 days
+                OpenIdTimeToLive = TimeSpan.FromDays(configData.GetInt(OPEN_ID_TTL_KEY, 7))
             };
         }
 

--- a/asa-manager/WebService/WebService.csproj
+++ b/asa-manager/WebService/WebService.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.2" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.3" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="2.1.5" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Services\Services.csproj" />

--- a/asa-manager/WebService/appsettings.ini
+++ b/asa-manager/WebService/appsettings.ini
@@ -121,6 +121,12 @@ aadTenantId=""
 ; Default: 2 minutes
 clockSkewSeconds = 300
 
+[TelemetryService:ClientAuth:OpenIdConnect]
+; Time to live for the OpenId Connect validation token.
+; The metadata settings will expire so the token needs to be periodically recreated.
+; Default: 7 days
+timeToLiveDays = 7
+
 [ExternalDependencies]
 ; The Device Telemetry service is used to retrieve the list
 ; of monitoring rules, which are used to generate ASA Jobs configuration

--- a/auth/Services/Services.csproj
+++ b/auth/Services/Services.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="2.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.8" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="2.1.4" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.4" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />

--- a/auth/Services/Services.csproj
+++ b/auth/Services/Services.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="2.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.4" />
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="2.0.6" />
+    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="data\policies\roles.json">

--- a/auth/Services/Services.csproj
+++ b/auth/Services/Services.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.8" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.4" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/auth/WebService/Auth/AuthMiddleware.cs
+++ b/auth/WebService/Auth/AuthMiddleware.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Azure.IoTSolutions.Auth.WebService.Auth
         private TokenValidationParameters tokenValidationParams;
         private readonly bool authRequired;
         private bool tokenValidationInitialized;
+        private DateTime tokenValidationExpiration;
 
         public AuthMiddleware(
             // ReSharper disable once UnusedParameter.Local
@@ -71,6 +72,7 @@ namespace Microsoft.Azure.IoTSolutions.Auth.WebService.Auth
             this.log = log;
             this.authRequired = config.AuthRequired;
             this.tokenValidationInitialized = false;
+            this.tokenValidationExpiration = DateTime.UtcNow;
 
             // This will show in development mode, or in case auth is turned off
             if (!this.authRequired)
@@ -87,7 +89,8 @@ namespace Microsoft.Azure.IoTSolutions.Auth.WebService.Auth
                     this.config.JwtIssuer,
                     this.config.JwtAudience,
                     this.config.JwtAllowedAlgos,
-                    this.config.JwtClockSkew
+                    this.config.JwtClockSkew,
+                    this.config.OpenIdTimeToLive
                 });
 
                 this.InitializeTokenValidationAsync(CancellationToken.None).Wait();
@@ -220,7 +223,8 @@ namespace Microsoft.Azure.IoTSolutions.Auth.WebService.Auth
 
         private async Task<bool> InitializeTokenValidationAsync(CancellationToken token)
         {
-            if (this.tokenValidationInitialized) return true;
+            // If the token has been initialized and is not past expiry, return.
+            if (this.tokenValidationInitialized && !this.TokenValidationExpired()) return true;
 
             try
             {
@@ -248,6 +252,7 @@ namespace Microsoft.Azure.IoTSolutions.Auth.WebService.Auth
                 };
 
                 this.tokenValidationInitialized = true;
+                this.tokenValidationExpiration = DateTime.UtcNow.Add(this.config.OpenIdTimeToLive);
             }
             catch (Exception e)
             {
@@ -255,6 +260,15 @@ namespace Microsoft.Azure.IoTSolutions.Auth.WebService.Auth
             }
 
             return this.tokenValidationInitialized;
+        }
+
+        /// <summary>
+        /// Checks if the OpenId Connect token has hit the expiration time.
+        /// </summary>
+        /// <returns>true if the token has expired</returns>
+        private bool TokenValidationExpired()
+        {
+            return this.tokenValidationExpiration > DateTime.UtcNow;
         }
     }
 }

--- a/auth/WebService/Auth/ClientAuthConfig.cs
+++ b/auth/WebService/Auth/ClientAuthConfig.cs
@@ -42,6 +42,12 @@ namespace Microsoft.Azure.IoTSolutions.Auth.WebService.Auth
         // Clock skew allowed when validating tokens expiration
         // Default: 2 minutes
         TimeSpan JwtClockSkew { get; set; }
+
+        // Time to live for the OpenId Connect validation token.
+        // The metadata settings will expire so the token needs to be
+        // periodically recreated.
+        // Default: 7 days
+        TimeSpan OpenIdTimeToLive { get; set; }
     }
 
     public class ClientAuthConfig : IClientAuthConfig
@@ -57,5 +63,6 @@ namespace Microsoft.Azure.IoTSolutions.Auth.WebService.Auth
         public string JwtAudienceSecret { get; set; }
         public string ArmEndpointUrl { get; set; }
         public TimeSpan JwtClockSkew { get; set; }
+        public TimeSpan OpenIdTimeToLive { get; set; }
     }
 }

--- a/auth/WebService/Runtime/Config.cs
+++ b/auth/WebService/Runtime/Config.cs
@@ -44,8 +44,10 @@ namespace Microsoft.Azure.IoTSolutions.Auth.WebService.Runtime
         private const string JWT_ALGOS_KEY = JWT_KEY + "allowedAlgorithms";
         private const string JWT_ISSUER_KEY = JWT_KEY + "authIssuer";
         private const string JWT_AUDIENCE_KEY = JWT_KEY + "aadAppId";
-
         private const string JWT_CLOCK_SKEW_KEY = JWT_KEY + "clockSkewSeconds";
+
+        private const string OPEN_ID_KEY = APPLICATION_KEY + "ClientAuth:OpenIdConnect:";
+        private const string OPEN_ID_TTL_KEY = OPEN_ID_KEY + "timeToLiveDays";
 
         public const string DEFAULT_ARM_ENDPOINT_URL = "https://management.azure.com/";
         public const string DEFAULT_AAD_ENDPOINT_URL = "https://login.microsoftonline.com/";
@@ -86,6 +88,8 @@ namespace Microsoft.Azure.IoTSolutions.Auth.WebService.Runtime
                 JwtAudience = configData.GetString(JWT_AUDIENCE_KEY, String.Empty),
                 // By default the allowed clock skew is 2 minutes
                 JwtClockSkew = TimeSpan.FromSeconds(configData.GetInt(JWT_CLOCK_SKEW_KEY, 120)),
+                // By default the time to live for the OpenId connect token is 7 days
+                OpenIdTimeToLive = TimeSpan.FromDays(configData.GetInt(OPEN_ID_TTL_KEY, 7))
             };
         }
 

--- a/auth/WebService/WebService.csproj
+++ b/auth/WebService/WebService.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="2.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="2.1.4" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Services\Services.csproj" />

--- a/auth/WebService/appsettings.ini
+++ b/auth/WebService/appsettings.ini
@@ -57,6 +57,12 @@ aadAppId=""
 ; Default: 2 minutes
 clockSkewSeconds = 300
 
+[TelemetryService:ClientAuth:OpenIdConnect]
+; Time to live for the OpenId Connect validation token.
+; The metadata settings will expire so the token needs to be periodically recreated.
+; Default: 7 days
+timeToLiveDays = 7
+
 [KeyVault]
 aadAppId = ${PCS_AAD_APPID}
 aadAppSecret = ${PCS_AAD_APPSECRET}

--- a/config/Services/Services.csproj
+++ b/config/Services/Services.csproj
@@ -22,8 +22,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.5.0"  />
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="2.0.6" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Data\device-simulation-template.json">

--- a/config/WebService/Auth/AuthMiddleware.cs
+++ b/config/WebService/Auth/AuthMiddleware.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.Auth
         private TokenValidationParameters tokenValidationParams;
         private readonly bool authRequired;
         private bool tokenValidationInitialized;
+        private DateTime tokenValidationExpiration;
         private readonly IUserManagementClient userManagementClient;
 
         public AuthMiddleware(
@@ -70,6 +71,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.Auth
             this.log = log;
             this.authRequired = config.AuthRequired;
             this.tokenValidationInitialized = false;
+            this.tokenValidationExpiration = DateTime.UtcNow;
             this.userManagementClient = userManagementClient;
 
             // This will show in development mode, or in case auth is turned off
@@ -87,7 +89,8 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.Auth
                     this.config.JwtIssuer,
                     this.config.JwtAudience,
                     this.config.JwtAllowedAlgos,
-                    this.config.JwtClockSkew
+                    this.config.JwtClockSkew,
+                    this.config.OpenIdTimeToLive
                 });
 
                 this.InitializeTokenValidationAsync(CancellationToken.None).Wait();
@@ -220,7 +223,8 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.Auth
 
         private async Task<bool> InitializeTokenValidationAsync(CancellationToken token)
         {
-            if (this.tokenValidationInitialized) return true;
+            // If the token has been initialized and is not past expiry, return.
+            if (this.tokenValidationInitialized && !this.TokenValidationExpired()) return true;
 
             try
             {
@@ -248,6 +252,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.Auth
                 };
 
                 this.tokenValidationInitialized = true;
+                this.tokenValidationExpiration = DateTime.UtcNow.Add(this.config.OpenIdTimeToLive);
             }
             catch (Exception e)
             {
@@ -255,6 +260,15 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.Auth
             }
 
             return this.tokenValidationInitialized;
+        }
+
+        /// <summary>
+        /// Checks if the OpenId Connect token has hit the expiration time.
+        /// </summary>
+        /// <returns>true if the token has expired</returns>
+        private bool TokenValidationExpired()
+        {
+            return this.tokenValidationExpiration > DateTime.UtcNow;
         }
     }
 }

--- a/config/WebService/Auth/ClientAuthConfig.cs
+++ b/config/WebService/Auth/ClientAuthConfig.cs
@@ -36,6 +36,12 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.Auth
         // Clock skew allowed when validating tokens expiration
         // Default: 2 minutes
         TimeSpan JwtClockSkew { get; set; }
+
+        // Time to live for the OpenId Connect validation token.
+        // The metadata settings will expire so the token needs to be
+        // periodically recreated.
+        // Default: 7 days
+        TimeSpan OpenIdTimeToLive { get; set; }
     }
 
     public class ClientAuthConfig : IClientAuthConfig
@@ -49,5 +55,6 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.Auth
         public string JwtIssuer { get; set; }
         public string JwtAudience { get; set; }
         public TimeSpan JwtClockSkew { get; set; }
+        public TimeSpan OpenIdTimeToLive { get; set; }
     }
 }

--- a/config/WebService/Runtime/Config.cs
+++ b/config/WebService/Runtime/Config.cs
@@ -46,6 +46,9 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.Runtime
         private const string JWT_AUDIENCE_KEY = JWT_KEY + "aadAppId";
         private const string JWT_CLOCK_SKEW_KEY = JWT_KEY + "clockSkewSeconds";
 
+        private const string OPEN_ID_KEY = APPLICATION_KEY + "ClientAuth:OpenIdConnect:";
+        private const string OPEN_ID_TTL_KEY = OPEN_ID_KEY + "timeToLiveDays";
+
         private const string USER_MANAGEMENT_KEY = "UserManagementService:";
         private const string USER_MANAGEMENT_URL_KEY = USER_MANAGEMENT_KEY + "authWebServiceUrl";
 
@@ -94,6 +97,8 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.Runtime
                 JwtAudience = configData.GetString(JWT_AUDIENCE_KEY),
                 // By default the allowed clock skew is 2 minutes
                 JwtClockSkew = TimeSpan.FromSeconds(configData.GetInt(JWT_CLOCK_SKEW_KEY, 120)),
+                // By default the time to live for the OpenId connect token is 7 days
+                OpenIdTimeToLive = TimeSpan.FromDays(configData.GetInt(OPEN_ID_TTL_KEY, 7))
             };
         }
     }

--- a/config/WebService/WebService.csproj
+++ b/config/WebService/WebService.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="2.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="2.1.4" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Services\Services.csproj" />

--- a/config/WebService/appsettings.ini
+++ b/config/WebService/appsettings.ini
@@ -58,6 +58,12 @@ aadTenantId=""
 ; Default: 2 minutes
 clockSkewSeconds = 300
 
+[TelemetryService:ClientAuth:OpenIdConnect]
+; Time to live for the OpenId Connect validation token.
+; The metadata settings will expire so the token needs to be periodically recreated.
+; Default: 7 days
+timeToLiveDays = 7
+
 [KeyVault]
 aadAppId = ${PCS_AAD_APPID}
 aadAppSecret = ${PCS_AAD_APPSECRET}

--- a/device-telemetry/WebService/Auth/AuthMiddleware.cs
+++ b/device-telemetry/WebService/Auth/AuthMiddleware.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.Auth
         private TokenValidationParameters tokenValidationParams;
         private readonly bool authRequired;
         private bool tokenValidationInitialized;
+        private DateTime tokenValidationExpiration;
         private readonly IUserManagementClient userManagementClient;
 
         public AuthMiddleware(
@@ -70,6 +71,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.Auth
             this.log = log;
             this.authRequired = config.AuthRequired;
             this.tokenValidationInitialized = false;
+            this.tokenValidationExpiration = DateTime.UtcNow;
             this.userManagementClient = userManagementClient;
 
             // This will show in development mode, or in case auth is turned off
@@ -87,7 +89,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.Auth
                     this.config.JwtIssuer,
                     this.config.JwtAudience,
                     this.config.JwtAllowedAlgos,
-                    this.config.JwtClockSkew
+                    this.config.JwtClockSkew,
+                    this.config.OpenIdTimeToLive
                 });
 
                 this.InitializeTokenValidationAsync(CancellationToken.None).Wait();
@@ -220,7 +223,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.Auth
 
         private async Task<bool> InitializeTokenValidationAsync(CancellationToken token)
         {
-            if (this.tokenValidationInitialized) return true;
+            // If the token has been initialized and is not past expiry, return.
+            if (this.tokenValidationInitialized && !this.TokenValidationExpired()) return true;
 
             try
             {
@@ -248,6 +252,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.Auth
                 };
 
                 this.tokenValidationInitialized = true;
+                this.tokenValidationExpiration = DateTime.UtcNow.Add(this.config.OpenIdTimeToLive);
             }
             catch (Exception e)
             {
@@ -255,6 +260,15 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.Auth
             }
 
             return this.tokenValidationInitialized;
+        }
+
+        /// <summary>
+        /// Checks if the OpenId Connect token has hit the expiration time.
+        /// </summary>
+        /// <returns>true if the token has expired</returns>
+        private bool TokenValidationExpired()
+        {
+            return this.tokenValidationExpiration > DateTime.UtcNow;
         }
     }
 }

--- a/device-telemetry/WebService/Auth/ClientAuthConfig.cs
+++ b/device-telemetry/WebService/Auth/ClientAuthConfig.cs
@@ -36,6 +36,12 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.Auth
         // Clock skew allowed when validating tokens expiration
         // Default: 2 minutes
         TimeSpan JwtClockSkew { get; set; }
+
+        // Time to live for the OpenId Connect validation token.
+        // The metadata settings will expire so the token needs to be
+        // periodically recreated.
+        // Default: 7 days
+        TimeSpan OpenIdTimeToLive { get; set; }
     }
 
     public class ClientAuthConfig : IClientAuthConfig
@@ -49,5 +55,6 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.Auth
         public string JwtIssuer { get; set; }
         public string JwtAudience { get; set; }
         public TimeSpan JwtClockSkew { get; set; }
+        public TimeSpan OpenIdTimeToLive { get; set; }
     }
 }

--- a/device-telemetry/WebService/Runtime/Config.cs
+++ b/device-telemetry/WebService/Runtime/Config.cs
@@ -70,6 +70,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.Runtime
         private const string JWT_AUDIENCE_KEY = JWT_KEY + "aadAppId";
         private const string JWT_CLOCK_SKEW_KEY = JWT_KEY + "clockSkewSeconds";
 
+        private const string OPEN_ID_KEY = APPLICATION_KEY + "ClientAuth:OpenIdConnect:";
+        private const string OPEN_ID_TTL_KEY = OPEN_ID_KEY + "timeToLiveDays";
+
         private const string ACTIONS_KEY = "Actions:";
         private const string ACTIONS_EVENTHUB_NAME = ACTIONS_KEY + "actionsEventHubName";
         private const string ACTIONS_EVENTHUB_CONNSTRING = ACTIONS_KEY + "actionsEventHubConnectionString";
@@ -136,6 +139,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.Runtime
                 JwtAudience = configData.GetString(JWT_AUDIENCE_KEY, String.Empty),
                 // By default the allowed clock skew is 2 minutes
                 JwtClockSkew = TimeSpan.FromSeconds(configData.GetInt(JWT_CLOCK_SKEW_KEY, 120)),
+                // By default the time to live for the OpenId connect token is 7 days
+                OpenIdTimeToLive = TimeSpan.FromDays(configData.GetInt(OPEN_ID_TTL_KEY, 7))
             };
         }
     }

--- a/device-telemetry/WebService/WebService.csproj
+++ b/device-telemetry/WebService/WebService.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="2.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="2.1.4" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Services\Services.csproj" />

--- a/device-telemetry/WebService/appsettings.ini
+++ b/device-telemetry/WebService/appsettings.ini
@@ -93,6 +93,12 @@ aadAppId=""
 ; Default: 2 minutes
 clockSkewSeconds = 300
 
+[TelemetryService:ClientAuth:OpenIdConnect]
+; Time to live for the OpenId Connect validation token.
+; The metadata settings will expire so the token needs to be periodically recreated.
+; Default: 7 days
+timeToLiveDays = 7
+
 [KeyVault]
 aadAppId = ${PCS_AAD_APPID}
 aadAppSecret = ${PCS_AAD_APPSECRET}

--- a/iothub-manager/WebService/Auth/AuthMiddleware.cs
+++ b/iothub-manager/WebService/Auth/AuthMiddleware.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.Auth
         private TokenValidationParameters tokenValidationParams;
         private readonly bool authRequired;
         private bool tokenValidationInitialized;
+        private DateTime tokenValidationExpiration;
         private readonly IUserManagementClient userManagementClient;
 
         public AuthMiddleware(
@@ -70,6 +71,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.Auth
             this.log = log;
             this.authRequired = config.AuthRequired;
             this.tokenValidationInitialized = false;
+            this.tokenValidationExpiration = DateTime.UtcNow;
             this.userManagementClient = userManagementClient;
 
             // This will show in development mode, or in case auth is turned off
@@ -87,7 +89,8 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.Auth
                     this.config.JwtIssuer,
                     this.config.JwtAudience,
                     this.config.JwtAllowedAlgos,
-                    this.config.JwtClockSkew
+                    this.config.JwtClockSkew,
+                    this.config.OpenIdTimeToLive
                 });
 
                 this.InitializeTokenValidationAsync(CancellationToken.None).Wait();
@@ -220,7 +223,8 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.Auth
 
         private async Task<bool> InitializeTokenValidationAsync(CancellationToken token)
         {
-            if (this.tokenValidationInitialized) return true;
+            // If the token has been initialized and is not past expiry, return.
+            if (this.tokenValidationInitialized && !this.TokenValidationExpired()) return true;
 
             try
             {
@@ -248,6 +252,7 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.Auth
                 };
 
                 this.tokenValidationInitialized = true;
+                this.tokenValidationExpiration = DateTime.UtcNow.Add(this.config.OpenIdTimeToLive);
             }
             catch (Exception e)
             {
@@ -255,6 +260,15 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.Auth
             }
 
             return this.tokenValidationInitialized;
+        }
+
+        /// <summary>
+        /// Checks if the OpenId Connect token has hit the expiration time.
+        /// </summary>
+        /// <returns>true if the token has expired</returns>
+        private bool TokenValidationExpired()
+        {
+            return this.tokenValidationExpiration > DateTime.UtcNow;
         }
     }
 }

--- a/iothub-manager/WebService/Auth/ClientAuthConfig.cs
+++ b/iothub-manager/WebService/Auth/ClientAuthConfig.cs
@@ -36,6 +36,12 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.Auth
         // Clock skew allowed when validating tokens expiration
         // Default: 2 minutes
         TimeSpan JwtClockSkew { get; set; }
+
+        // Time to live for the OpenId Connect validation token.
+        // The metadata settings will expire so the token needs to be
+        // periodically recreated.
+        // Default: 7 days
+        TimeSpan OpenIdTimeToLive { get; set; }
     }
 
     public class ClientAuthConfig : IClientAuthConfig
@@ -49,5 +55,6 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.Auth
         public string JwtIssuer { get; set; }
         public string JwtAudience { get; set; }
         public TimeSpan JwtClockSkew { get; set; }
+        public TimeSpan OpenIdTimeToLive { get; set; }
     }
 }

--- a/iothub-manager/WebService/Runtime/Config.cs
+++ b/iothub-manager/WebService/Runtime/Config.cs
@@ -44,6 +44,9 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.Runtime
         private const string JWT_AUDIENCE_KEY = JWT_KEY + "aadAppId";
         private const string JWT_CLOCK_SKEW_KEY = JWT_KEY + "clockSkewSeconds";
 
+        private const string OPEN_ID_KEY = APPLICATION_KEY + "ClientAuth:OpenIdConnect:";
+        private const string OPEN_ID_TTL_KEY = OPEN_ID_KEY + "timeToLiveDays";
+
         public int Port { get; }
         public IServicesConfig ServicesConfig { get; }
         public IClientAuthConfig ClientAuthConfig { get; }
@@ -94,6 +97,8 @@ namespace Microsoft.Azure.IoTSolutions.IotHubManager.WebService.Runtime
                 JwtAudience = configData.GetString(JWT_AUDIENCE_KEY),
                 // By default the allowed clock skew is 2 minutes
                 JwtClockSkew = TimeSpan.FromSeconds(configData.GetInt(JWT_CLOCK_SKEW_KEY, 120)),
+                // By default the time to live for the OpenId connect token is 7 days
+                OpenIdTimeToLive = TimeSpan.FromDays(configData.GetInt(OPEN_ID_TTL_KEY, 7))
             };
         }
     }

--- a/iothub-manager/WebService/WebService.csproj
+++ b/iothub-manager/WebService/WebService.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="2.1.4" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RecurringTasksAgent\RecurringTasksAgent.csproj" />

--- a/iothub-manager/WebService/appsettings.ini
+++ b/iothub-manager/WebService/appsettings.ini
@@ -49,6 +49,12 @@ aadAppId=""
 ; Default: 2 minutes
 clockSkewSeconds = 300
 
+[TelemetryService:ClientAuth:OpenIdConnect]
+; Time to live for the OpenId Connect validation token.
+; The metadata settings will expire so the token needs to be periodically recreated.
+; Default: 7 days
+timeToLiveDays = 7
+
 [KeyVault]
 aadAppId = ${PCS_AAD_APPID}
 aadAppSecret = ${PCS_AAD_APPSECRET}

--- a/iothub-manager/iothub-manager.sln.DotSettings
+++ b/iothub-manager/iothub-manager.sln.DotSettings
@@ -11,7 +11,6 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_NESTED_USINGS_STMT/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_NESTED_WHILE_STMT/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/LINE_FEED_AT_FILE_END/@EntryValue">True</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/STICK_COMMENT/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
@@ -65,11 +64,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EUnitTestFramework_002ESettings_002EMigrations_002ERemoveBuildPolicyAlwaysMigration/@EntryIndexedValue">True</s:Boolean>

--- a/iothub-manager/iothub-manager.sln.DotSettings
+++ b/iothub-manager/iothub-manager.sln.DotSettings
@@ -11,6 +11,7 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_NESTED_USINGS_STMT/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_NESTED_WHILE_STMT/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/LINE_FEED_AT_FILE_END/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/STICK_COMMENT/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
@@ -64,7 +65,11 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EUnitTestFramework_002ESettings_002EMigrations_002ERemoveBuildPolicyAlwaysMigration/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
<!-- Please provide enough information so others can review your pull request -->
After roughly 2 months, the auth middleware had stale metadata for OpenIdConnect. This change adds a TTL for the OpenIdConnect object, after the TTL, the service will fetch a new instance.

# Motivation for the change
<!-- Please explain the motivation for making this change -->
https://github.com/Azure/remote-monitoring-services-dotnet/issues/233 
