### PR TITLE
OS Agnostic Path Separators in Device Telemetry Unit Tests

### DIFF
--- a/device-telemetry/ActionsAgent.Test/ActionManagerTest.cs
+++ b/device-telemetry/ActionsAgent.Test/ActionManagerTest.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Net;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Azure.IoTSolutions.DeviceTelemetry.ActionsAgent.Actions;
 using Microsoft.Azure.IoTSolutions.DeviceTelemetry.ActionsAgent.Models;
@@ -24,13 +25,14 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.ActionsAgent.Test
         {
             Mock<ILogger> loggerMock = new Mock<ILogger>();
             this.httpClientMock = new Mock<IHttpClient>();
+
+            char pathSeparator = Path.DirectorySeparatorChar;
             IServicesConfig servicesConfig = new ServicesConfig
             {
                 LogicAppEndpointUrl = "https://azure.com",
                 SolutionUrl = "test",
-                TemplateFolder = ".\\data\\"
+                TemplateFolder = $".{pathSeparator}data{pathSeparator}"
             };
-
             this.actionManager = new ActionManager(loggerMock.Object, servicesConfig, this.httpClientMock.Object);
         }
 

--- a/device-telemetry/ActionsAgent.Test/ActionManagerTest.cs
+++ b/device-telemetry/ActionsAgent.Test/ActionManagerTest.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
-using System.Net;
 using System.IO;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.IoTSolutions.DeviceTelemetry.ActionsAgent.Actions;
 using Microsoft.Azure.IoTSolutions.DeviceTelemetry.ActionsAgent.Models;

--- a/device-telemetry/Services.Test/TimeSeries/TimeSeriesValueListApiModelTest.cs
+++ b/device-telemetry/Services.Test/TimeSeries/TimeSeriesValueListApiModelTest.cs
@@ -11,7 +11,7 @@ namespace Services.Test.TimeSeries
 {
     public class TimeSeriesValueListApiModelTest
     {
-        private readonly string TSI_SAMPLE_EVENTS_FILE = @"TimeSeries\TimeSeriesEvents.json";
+        private readonly string TSI_SAMPLE_EVENTS_FILE = $"TimeSeries{Path.DirectorySeparatorChar}TimeSeriesEvents.json";
 
         [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
         public void ConvertsToMessageList_WhenMultipleDeviceTypes()


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
<!-- Please provide enough information so others can review your pull request -->
Usage of the Path.DirectorySeparatorChar in place of "\" in some of the Device Telemetry unit tests. Before this change, the tests in the changed files would fail on MacOS.

# Motivation for the change
<!-- Please explain the motivation for making this change -->
OS agnostic unit tests
