### PR TITLE
 Align "USER_MANAGEMENT_URL_KEY" with its definition in appsettings.ini

### DIFF
--- a/config/WebService/Runtime/Config.cs
+++ b/config/WebService/Runtime/Config.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.Runtime
         private const string EXTERNAL_DEPENDENCIES_KEY = "ExternalDependencies:";
         private const string STORAGE_ADAPTER_URL_KEY = EXTERNAL_DEPENDENCIES_KEY + "storageAdapterWebServiceUrl";
         private const string DEVICE_SIMULATION_URL_KEY = EXTERNAL_DEPENDENCIES_KEY + "deviceSimulationWebServiceUrl";
-        private const string TELEMETRY_URL_KEY = EXTERNAL_DEPENDENCIES_KEY + "telemetryWebServiceUrl";
+        private const string TELEMETRY_URL_KEY = EXTERNAL_DEPENDENCIES_KEY + "telemetryWebServiceUrl";		       
+        private const string USER_MANAGEMENT_URL_KEY = EXTERNAL_DEPENDENCIES_KEY + "authWebServiceUrl";
 
         private const string DEVICE_SIMULATION_KEY = "DeviceSimulationService:";
         private const string TELEMETRY_KEY = "TelemetryService:";
@@ -49,8 +50,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.Runtime
         private const string OPEN_ID_KEY = APPLICATION_KEY + "ClientAuth:OpenIdConnect:";
         private const string OPEN_ID_TTL_KEY = OPEN_ID_KEY + "timeToLiveDays";
 
-        private const string USER_MANAGEMENT_KEY = "UserManagementService:";
-        private const string USER_MANAGEMENT_URL_KEY = USER_MANAGEMENT_KEY + "authWebServiceUrl";
+
 
         private const string ACTIONS_KEY = APPLICATION_KEY + "Actions:";
         private const string OFFICE365_LOGIC_APP_URL_KEY = ACTIONS_KEY + "office365ConnectionUrl";


### PR DESCRIPTION

# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [x] All new and existing tests passed.
- [x] The code follows the code style and conventions of this project.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change
<!-- Please provide enough information so others can review your pull request -->
It's an empty string when getting the value of "USER_MANAGEMENT_URL_KEY".
In the [appsettings.ini](https://github.com/Azure/remote-monitoring-services-dotnet/blob/master/config/WebService/appsettings.ini#12):
```
[ExternalDependencies]
;; Urls to external services
storageAdapterWebServiceUrl = ""
deviceSimulationWebServiceUrl = ""
telemetryWebServiceUrl = ""
authWebServiceUrl = ""
```
 But [the original code](https://github.com/Azure/remote-monitoring-services-dotnet/blob/master/config/WebService/Runtime/Config.cs#52) means getting the value from **[UserManagementService:authWebServiceUrl]**:
```
       private const string USER_MANAGEMENT_KEY = "UserManagementService:";
       private const string USER_MANAGEMENT_URL_KEY = USER_MANAGEMENT_KEY + "authWebServiceUrl";

```

# Motivation for the change
<!-- Please explain the motivation for making this change -->

Fix it